### PR TITLE
Add (basic) support for footnotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
 
 <body>
   <div id="content" hidden>
+    <p>
+      This paragraph has a footnote<footnote>A note placed at the bottom of a page of a book or manuscript that comments
+        on or cites a reference for a designated
+        part of the text.</footnote> in it. And another<footnote>Distinctly different from the first.</footnote> one.
+    </p>
     <p>Hello world, this is the ProseMirror editor.</p>
     <div class="call-to-action">
       <p>Call to action</p>

--- a/main.js
+++ b/main.js
@@ -5,10 +5,18 @@ import { EditorView } from "prosemirror-view"
 import { DOMParser } from "prosemirror-model"
 import schema from "./src/schema"
 import plugins from "./src/plugins"
+import FootnoteView from "./src/nodes/footnote/FootnoteView"
 
 window.view = new EditorView(document.querySelector("#editor"), {
   state: EditorState.create({
     doc: DOMParser.fromSchema(schema).parse(document.querySelector("#content")),
     plugins: plugins({ schema })
   })
+})
+
+window.view = new EditorView(document.querySelector("#editor"), {
+  state,
+  nodeViews: {
+    footnote(node, view, getPos) { return new FootnoteView(node, view, getPos) }
+  }
 })

--- a/scss/_footnotes.scss
+++ b/scss/_footnotes.scss
@@ -1,0 +1,62 @@
+.ProseMirror {
+  counter-reset: prosemirror-footnote;
+}
+
+footnote {
+  display: inline-block;
+  cursor: pointer;
+}
+
+footnote::before {
+  content: "[footnote " counter(prosemirror-footnote) "]";
+  color: $govuk-link-colour;
+  vertical-align: super;
+  font-size: 75%;
+  counter-increment: prosemirror-footnote;
+}
+
+.ProseMirror-hideselection .footnote-tooltip *::selection {
+  background-color: transparent;
+}
+
+.ProseMirror-hideselection .footnote-tooltip *::-moz-selection {
+  background-color: transparent;
+}
+
+.footnote-tooltip {
+  cursor: auto;
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  margin-top: 3px;
+  background: #fff;
+  padding: 3px;
+  border: 2px solid $govuk-input-border-colour;
+  box-shadow: 0 8px 8px rgba(0, 0, 0, 0.3);
+}
+
+.footnote-tooltip:after,
+.footnote-tooltip:before {
+  bottom: 100%;
+  border: solid transparent;
+  content: "";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+  left: calc(var(--arrow-left) - 1rem - 5px);
+}
+
+.footnote-tooltip:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-bottom-color: #fff;
+  border-width: 5px;
+  margin-left: -5px;
+}
+
+.footnote-tooltip:before {
+  border-color: rgba(11, 12, 12, 0);
+  border-bottom-color: $govuk-input-border-colour;
+  border-width: 8px;
+  margin-left: -8px;
+}

--- a/src/nodes/footnote.js
+++ b/src/nodes/footnote.js
@@ -1,0 +1,14 @@
+export const name = "footnote"
+
+export const schema = {
+  content: "text*",
+  group: "inline",
+  inline: true,
+  atom: true,
+  toDOM: () => ["footnote", 0],
+  parseDOM: [{ tag: "footnote" }],
+}
+
+export const buildMenu = ({ menu, schema }) => { }
+
+export const inputRules = (schema) => ([])

--- a/src/nodes/footnote/FootnoteView.js
+++ b/src/nodes/footnote/FootnoteView.js
@@ -1,0 +1,125 @@
+/**
+ * This [node view][1] handles rendering the footnote content
+ * in a tooltip popup with an embedded editor.
+ * 
+ * It was heavily inspired by the [footnote demo][2] on the
+ * ProseMirror website.
+ * 
+ * [1]: https://prosemirror.net/docs/guide/#view.node_views
+ * [2]: https://prosemirror.net/examples/footnote/
+ */
+
+import { StepMap } from "prosemirror-transform"
+import { keymap } from "prosemirror-keymap"
+import { undo, redo } from "prosemirror-history"
+import { EditorState } from "prosemirror-state"
+import { EditorView } from "prosemirror-view"
+
+export default class FootnoteView {
+  constructor(node, view, getPos) {
+    // We'll need these later
+    this.node = node
+    this.outerView = view
+    this.getPos = getPos
+
+    // The node's representation in the editor (empty, for now)
+    this.dom = document.createElement("footnote")
+    // These are used when the footnote is selected
+    this.innerView = null
+  }
+
+  selectNode() {
+    this.dom.classList.add("ProseMirror-selectednode")
+    if (!this.innerView) this.open()
+  }
+
+  deselectNode() {
+    this.dom.classList.remove("ProseMirror-selectednode")
+    if (this.innerView) this.close()
+  }
+
+  open() {
+    // Append a tooltip to the outer node
+    let tooltip = this.dom.appendChild(document.createElement("div"))
+    tooltip.className = "footnote-tooltip"
+    tooltip.style.setProperty("--arrow-left", this.getTooltipArrowLeftPosition() + "px")
+    // And put a sub-ProseMirror into that
+    this.innerView = new EditorView(tooltip, {
+      // You can use any node as an editor document
+      state: EditorState.create({
+        doc: this.node,
+        plugins: [keymap({
+          "Mod-z": () => undo(this.outerView.state, this.outerView.dispatch),
+          "Mod-y": () => redo(this.outerView.state, this.outerView.dispatch),
+          "Shift-Mod-z": () => redo(this.outerView.state, this.outerView.dispatch),
+        })]
+      }),
+      // This is the magic part
+      dispatchTransaction: this.dispatchInner.bind(this),
+      handleDOMEvents: {
+        mousedown: () => {
+          // Kludge to prevent issues due to the fact that the whole
+          // footnote is node-selected (and thus DOM-selected) when
+          // the parent editor is focused.
+          if (this.outerView.hasFocus()) this.innerView.focus()
+        }
+      }
+    })
+  }
+
+  close() {
+    this.innerView.destroy()
+    this.innerView = null
+    this.dom.textContent = ""
+  }
+
+  getTooltipArrowLeftPosition() {
+    const editor = this.outerView.dom.getBoundingClientRect()
+    const footnote = this.dom.getBoundingClientRect()
+    return Math.round(footnote.left + (footnote.width / 2) - editor.left);
+  }
+
+  dispatchInner(tr) {
+    let { state, transactions } = this.innerView.state.applyTransaction(tr)
+    this.innerView.updateState(state)
+
+    if (!tr.getMeta("fromOutside")) {
+      let outerTr = this.outerView.state.tr, offsetMap = StepMap.offset(this.getPos() + 1)
+      for (let i = 0; i < transactions.length; i++) {
+        let steps = transactions[i].steps
+        for (let j = 0; j < steps.length; j++)
+          outerTr.step(steps[j].map(offsetMap))
+      }
+      if (outerTr.docChanged) this.outerView.dispatch(outerTr)
+    }
+  }
+
+  update(node) {
+    if (!node.sameMarkup(this.node)) return false
+    this.node = node
+    if (this.innerView) {
+      let state = this.innerView.state
+      let start = node.content.findDiffStart(state.doc.content)
+      if (start != null) {
+        let { a: endA, b: endB } = node.content.findDiffEnd(state.doc.content)
+        let overlap = start - Math.min(endA, endB)
+        if (overlap > 0) { endA += overlap; endB += overlap }
+        this.innerView.dispatch(
+          state.tr
+            .replace(start, endB, node.slice(start, endA))
+            .setMeta("fromOutside", true))
+      }
+    }
+    return true
+  }
+
+  destroy() {
+    if (this.innerView) this.close()
+  }
+
+  stopEvent(event) {
+    return this.innerView && this.innerView.dom.contains(event.target)
+  }
+
+  ignoreMutation() { return true }
+}

--- a/style.scss
+++ b/style.scss
@@ -12,6 +12,7 @@
 @import "prosemirror-menu/style/menu.css";
 @import "./scss/prosemirror-example-setup";
 @import "prosemirror-gapcursor/style/gapcursor.css";
+@import "./scss/footnotes";
 
 :root {
   font-family: system-ui, sans-serif;


### PR DESCRIPTION
Following the ProseMirror example:
https://prosemirror.net/examples/footnote/

This isn't fully featured. Since the footnote content is rendered in a sub-editor, the usual input rules and controls are missing.

This includes:
- missing 'smart quote' input rules
- missing formatting keyboard shortcuts
- missing formatting toolbar for marks (e.g. bold, hyperlinks, etc.)

...but it's a decent start.