### PR TITLE
Add basic markdown support

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
 <body>
   <div id="content" hidden>
     <p>Hello world, this is the ProseMirror editor.</p>
+    <ol>
+      <li><p>First</p></li>
+      <li><p>Second</p></li>
+      <li><p>Third</p></li>
+    </ol>
     <div class="call-to-action">
       <p>Call to action</p>
     </div>
@@ -20,7 +25,10 @@
       <p>This is an information callout</p>
     </div>
   </div>
-  <div id="editor"></div>
+  <div id="container">
+    <div id="editor"></div>
+    <pre id="markdown"></pre>
+  </div>
   <script type="module" src="/main.js"></script>
 </body>
 

--- a/main.js
+++ b/main.js
@@ -3,12 +3,22 @@ import './style.scss'
 import { EditorState } from "prosemirror-state"
 import { EditorView } from "prosemirror-view"
 import { DOMParser } from "prosemirror-model"
+import { markdownSerializer} from "./src/markdown"
 import schema from "./src/schema"
 import plugins from "./src/plugins"
 
-window.view = new EditorView(document.querySelector("#editor"), {
-  state: EditorState.create({
-    doc: DOMParser.fromSchema(schema).parse(document.querySelector("#content")),
-    plugins: plugins({ schema })
-  })
+let state = EditorState.create({
+  doc: DOMParser.fromSchema(schema).parse(document.querySelector("#content")),
+  plugins: plugins({ schema })
 })
+
+window.view = new EditorView(document.querySelector("#editor"), {
+  state,
+  dispatchTransaction(transaction) {
+    let newState = view.state.apply(transaction)
+    view.updateState(newState)
+    document.querySelector('pre').textContent = markdownSerializer.serialize(window.view.state.doc)
+  }
+})
+
+document.querySelector('pre').textContent = markdownSerializer.serialize(window.view.state.doc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "govuk_publishing_components": "github:alphagov/govuk_publishing_components",
         "govuk-frontend": "^4.7.0",
         "prosemirror-example-setup": "^1.2.2",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.11.2",
         "prosemirror-model": "^1.19.3",
         "prosemirror-schema-basic": "^1.2.2",
         "prosemirror-schema-list": "^1.3.0",
@@ -424,6 +426,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/axe-core": {
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
@@ -484,6 +491,17 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
@@ -682,6 +700,34 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -856,6 +902,15 @@
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.11.2.tgz",
+      "integrity": "sha512-Eu5g4WPiCdqDTGhdSsG9N6ZjACQRYrsAkrF9KYfdMaCmjIApH75aVncsWYOJvEk2i1B3i8jZppv3J/tnuHGiUQ==",
+      "dependencies": {
+        "markdown-it": "^13.0.1",
+        "prosemirror-model": "^1.0.0"
       }
     },
     "node_modules/prosemirror-menu": {
@@ -1051,6 +1106,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "govuk_publishing_components": "github:alphagov/govuk_publishing_components",
     "govuk-frontend": "^4.7.0",
     "prosemirror-example-setup": "^1.2.2",
+    "prosemirror-keymap": "^1.2.2",
+    "prosemirror-markdown": "^1.11.2",
     "prosemirror-model": "^1.19.3",
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-schema-list": "^1.3.0",

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -1,0 +1,98 @@
+import { MarkdownSerializer } from "prosemirror-markdown"
+
+export const markdownSerializer = new MarkdownSerializer({
+  blockquote(state, node) {
+    state.wrapBlock("> ", null, node, () => state.renderContent(node))
+  },
+  code_block(state, node) {
+    // Make sure the front matter fences are longer than any dash sequence within it
+    const backticks = node.textContent.match(/`{3,}/gm)
+    const fence = backticks ? (backticks.sort().slice(-1)[0] + "`") : "```"
+
+    state.write(fence + (node.attrs.params || "") + "\n")
+    state.text(node.textContent, false)
+    // Add a newline to the current content before adding closing marker
+    state.write("\n")
+    state.write(fence)
+    state.closeBlock(node)
+  },
+  heading(state, node) {
+    state.write(state.repeat("#", node.attrs.level) + " ")
+    state.renderInline(node, false)
+    state.closeBlock(node)
+  },
+  horizontal_rule(state, node) {
+    state.write(node.attrs.markup || "---")
+    state.closeBlock(node)
+  },
+  bullet_list(state, node) {
+    state.renderList(node, "  ", () => (node.attrs.bullet || "*") + " ")
+  },
+  ordered_list(state, node) {
+    let start = node.attrs.order || 1
+    let maxW = String(start + node.childCount - 1).length
+    let space = state.repeat(" ", maxW + 2)
+    state.renderList(node, space, i => {
+      let nStr = String(start + i)
+      return state.repeat(" ", maxW - nStr.length) + nStr + ". "
+    })
+  },
+  list_item(state, node) {
+    state.renderContent(node)
+  },
+  paragraph(state, node) {
+    state.renderInline(node)
+    state.closeBlock(node)
+  },
+  image(state, node) {
+    state.write("![" + state.esc(node.attrs.alt || "") + "](" + node.attrs.src.replace(/[\(\)]/g, "\\$&") +
+                (node.attrs.title ? ' "' + node.attrs.title.replace(/"/g, '\\"') + '"' : "") + ")")
+  },
+  hard_break(state, node, parent, index) {
+    for (let i = index + 1; i < parent.childCount; i++)
+      if (parent.child(i).type != node.type) {
+        state.write("\\\n")
+        return
+      }
+  },
+  text(state, node) {
+    state.text(node.text, !state.inAutolink)
+  },
+  call_to_action(state, node) {
+    state.write("$CTA\n\n")
+    state.renderInline(node)
+    state.write("$CTA")
+    state.closeBlock(node)
+  },
+  warning_callout(state, node) {
+    state.write("%")
+    state.renderInline(node, false)
+    state.write("%")
+    state.closeBlock(node)
+  },
+  information_callout(state, node) {
+    state.write("^")
+    state.renderInline(node, false)
+    state.write("^")
+    state.closeBlock(node)
+  },
+}, {
+  em: {open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true},
+  strong: {open: "**", close: "**", mixable: true, expelEnclosingWhitespace: true},
+  link: {
+    open(state, mark, parent, index) {
+      state.inAutolink = isPlainURL(mark, parent, index)
+      return state.inAutolink ? "<" : "["
+    },
+    close(state, mark, parent, index) {
+      let {inAutolink} = state
+      state.inAutolink = undefined
+      return inAutolink ? ">"
+        : "](" + mark.attrs.href.replace(/[\(\)"]/g, "\\$&") + (mark.attrs.title ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"` : "") + ")"
+    },
+    mixable: true
+  },
+  code: {open(_state, _mark, parent, index) { return backticksFor(parent.child(index), -1) },
+         close(_state, _mark, parent, index) { return backticksFor(parent.child(index - 1), 1) },
+         escape: false}
+})

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,6 @@
 import { addListNodes } from "prosemirror-schema-list"
 import { Schema } from "prosemirror-model"
-import { schema as basicSchema } from "prosemirror-schema-basic"
+import { schema as basicSchema } from "prosemirror-markdown"
 import customNodes from "./nodes"
 
 // Use basic schema which roughly corresponds to the CommonMark schema

--- a/style.scss
+++ b/style.scss
@@ -17,15 +17,35 @@
   font-family: system-ui, sans-serif;
 }
 
+body {
+  margin: 0;
+}
+
+#container {
+  display: flex;
+  align-items: stretch;
+  width:100vw;
+}
+
 #editor,
-.editor {
+.editor,
+pre {
   background: white;
   color: black;
   background-clip: padding-box;
   border-radius: 4px;
   border: 2px solid rgba(0, 0, 0, 0.2);
   padding: 5px 0;
-  margin-bottom: 23px;
+  margin: 20px;
+  max-width: 50%;
+  overflow: hidden;
+}
+
+pre {
+  margin-left:0;
+  padding: 15px;
+  padding-top: 50px;
+  font-size: 16px;
 }
 
 .ProseMirror {


### PR DESCRIPTION
Use the markdown schema and define a custom markdown serialiser to serialise the node tree to markdown.

Display this in a side by side view with the existing editor.