### PR TITLE
Use `textarea` for govspeak

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -3,5 +3,5 @@ import GovspeakVisualEditor from '../main.js'
 new GovspeakVisualEditor(
 	document.querySelector("#content"),
 	document.querySelector("#editor"),
-	document.querySelector('pre')
+	document.querySelector('#govspeak')
 )

--- a/examples/index.html
+++ b/examples/index.html
@@ -27,7 +27,7 @@
   </div>
   <div id="container">
     <div id="editor"></div>
-    <pre id="markdown"></pre>
+    <textarea id="govspeak"></textarea>
   </div>
   <script type="module" src="./example.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -19,10 +19,10 @@ export default class GovspeakVisualEditor {
       dispatchTransaction(transaction) {
         let newState = view.state.apply(transaction)
         view.updateState(newState)
-        govspeak.textContent = markdownSerializer.serialize(window.view.state.doc)
+        govspeak.value = markdownSerializer.serialize(window.view.state.doc)
       }
     })
 
-    govspeak.textContent = markdownSerializer.serialize(window.view.state.doc)
+    govspeak.value = markdownSerializer.serialize(window.view.state.doc)
   }
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -22,33 +22,27 @@ body {
 }
 
 #container {
-  display: flex;
-  align-items: stretch;
   width:100vw;
+  box-sizing: border-box;
+  padding: 20px;
+
+  display: flex;
+  gap: 20px;
 }
 
 #editor,
-.editor,
-pre {
-  background: white;
-  color: black;
-  background-clip: padding-box;
+#govspeak {
+  flex: 1;
   border-radius: 4px;
   border: 2px solid rgba(0, 0, 0, 0.2);
-  padding: 5px 0;
-  margin: 20px;
-  max-width: 50%;
-  overflow: hidden;
+  padding: 5px 0 0;
 }
 
-pre {
-  margin-left:0;
-  padding: 15px;
-  padding-top: 50px;
+#govspeak {
+  padding: 50px 15px 15px;
   font-size: 16px;
 }
 
 .ProseMirror {
-  padding: 1rem;
-  outline: none;
+  padding: 15px;
 }


### PR DESCRIPTION
Use a textarea to display the govspeak as this is what will be needed to use the editor in a form.
Adjust the code and CSS around this and do some general cleanup.