### PR TITLE
Add missing functions to markdown conversion

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -96,3 +96,19 @@ export const markdownSerializer = new MarkdownSerializer({
          close(_state, _mark, parent, index) { return backticksFor(parent.child(index - 1), 1) },
          escape: false}
 })
+
+function backticksFor(node, side) {
+  let ticks = /`+/g, m, len = 0
+  if (node.isText) while (m = ticks.exec(node.text)) len = Math.max(len, m[0].length)
+  let result = len > 0 && side > 0 ? " `" : "`"
+  for (let i = 0; i < len; i++) result += "`"
+  if (len > 0 && side < 0) result += " "
+  return result
+}
+
+function isPlainURL(link, parent, index) {
+  if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false
+  let content = parent.child(index)
+  if (!content.isText || content.text != link.attrs.href || content.marks[content.marks.length - 1] != link) return false
+  return index == parent.childCount - 1 || !link.isInSet(parent.child(index + 1).marks)
+}


### PR DESCRIPTION
Some functions were left out when copying the serialiser leading to features such as links not working correctly.