### PR TITLE
Refactor node markdown serialization into node files

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -1,6 +1,6 @@
 import { MarkdownSerializer } from "prosemirror-markdown"
 
-export const markdownSerializer = new MarkdownSerializer({
+const defaultNodes = {
   blockquote(state, node) {
     state.wrapBlock("> ", null, node, () => state.renderContent(node))
   },
@@ -58,25 +58,15 @@ export const markdownSerializer = new MarkdownSerializer({
   text(state, node) {
     state.text(node.text, !state.inAutolink)
   },
-  call_to_action(state, node) {
-    state.write("$CTA\n\n")
-    state.renderInline(node)
-    state.write("$CTA")
-    state.closeBlock(node)
-  },
-  warning_callout(state, node) {
-    state.write("%")
-    state.renderInline(node, false)
-    state.write("%")
-    state.closeBlock(node)
-  },
-  information_callout(state, node) {
-    state.write("^")
-    state.renderInline(node, false)
-    state.write("^")
-    state.closeBlock(node)
-  },
-}, {
+}
+
+const globImport = import.meta.glob('./nodes/*.js', { eager: true });
+const modules = Object.values(globImport);
+const customNodes = Object.fromEntries(modules.map((node) => [node.name, node.toGovspeak]))
+
+const nodes = Object.assign(defaultNodes, customNodes);
+
+export const markdownSerializer = new MarkdownSerializer(nodes, {
   em: {open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true},
   strong: {open: "**", close: "**", mixable: true, expelEnclosingWhitespace: true},
   link: {

--- a/src/nodes/call_to_action.js
+++ b/src/nodes/call_to_action.js
@@ -23,3 +23,10 @@ export const inputRules = (schema) => ([
   // $CTA Call to action
   wrappingInputRule(/^\$CTA\s$/, schema.nodes[name]),
 ])
+
+export const toGovspeak = (state, node) => {
+  state.write("$CTA\n\n")
+  state.renderInline(node)
+  state.write("$CTA")
+  state.closeBlock(node)
+}

--- a/src/nodes/information_callout.js
+++ b/src/nodes/information_callout.js
@@ -23,3 +23,10 @@ export const inputRules = (schema) => ([
   // ^ Information callout
   textblockTypeInputRule(/^\^\s$/, schema.nodes[name]),
 ])
+
+export const toGovspeak = (state, node) => {
+  state.write("^")
+  state.renderInline(node, false)
+  state.write("^")
+  state.closeBlock(node)
+}

--- a/src/nodes/warning_callout.js
+++ b/src/nodes/warning_callout.js
@@ -23,3 +23,10 @@ export const inputRules = (schema) => ([
   // % Warning callout
   textblockTypeInputRule(/^%\s$/, schema.nodes[name]),
 ])
+
+export const toGovspeak = (state, node) => {
+  state.write("%")
+  state.renderInline(node, false)
+  state.write("%")
+  state.closeBlock(node)
+}


### PR DESCRIPTION
Add `toGovspeak` functions to the nodes and then import them into the markdown serialiser to centralise the node implementation.