### PR TITLE
Support for Example Callout markdown syntax

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -24,6 +24,13 @@
     <div role="note" aria-label="Information" class="application-notice info-notice">
       <p>This is an information callout</p>
     </div>
+    <div class="example">
+      <p>
+        This is an example callout
+        <br><br>
+        That works on multiple lines
+      </p>
+    </div>
     <div role="address" aria-label="Address" class="address">
       <p>
         HM Revenue and Customs

--- a/src/nodes/example_callout.js
+++ b/src/nodes/example_callout.js
@@ -1,0 +1,32 @@
+import {wrapItem} from "prosemirror-menu"
+import {wrappingInputRule} from "prosemirror-inputrules"
+
+export const name = "example_callout"
+
+export const schema = {
+  content: "block+",
+  group: "block",
+  defining: true,
+  parseDOM: [{ tag: `div.example` }],
+  toDOM() { return [ "div", { class: "example" }, 0 ] }
+}
+
+export const buildMenu = ({ menu, schema }) => {
+  menu.typeMenu.content.push(
+    wrapItem(schema.nodes[name], {
+      label: "Example callout"
+    })
+  )
+}
+
+export const inputRules = (schema) => ([
+  // $E Example callout
+  wrappingInputRule(/^\$E\s$/, schema.nodes[name]),
+])
+
+export const toGovspeak = (state, node) => {
+  state.write("$E\n\n")
+  state.renderInline(node)
+  state.write("$E")
+  state.closeBlock(node)
+}


### PR DESCRIPTION
Added support for example callouts.
https://govspeak-preview.publishing.service.gov.uk/guide#example-callout

https://trello.com/c/mrVoTxNd/2297-display-example-callout-in-the-visual-editor