### PR TITLE
Specify a publishing components verison

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vite-plugin-static-copy": "^0.17.0"
   },
   "dependencies": {
-    "govuk_publishing_components": "github:alphagov/govuk_publishing_components",
+    "govuk_publishing_components": "^37.2.3",
     "govuk-frontend": "^4.7.0",
     "prosemirror-example-setup": "^1.2.2",
     "prosemirror-keymap": "^1.2.2",


### PR DESCRIPTION
Not specifying a version was causing problems when adding the library as a whitehall dependency