### PR TITLE
Exclude bold emphasis and code blocks h1 from schema

### DIFF
--- a/e2e/lists.spec.js
+++ b/e2e/lists.spec.js
@@ -9,13 +9,12 @@ test.describe("bulleted list", () => {
   test("renders bullet list menu items", async ({ page }) => {
     await page.getByText("1.", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const visibleMenuButtons = ["B"];
+    const visibleMenuButtons = [];
     const disabledMenuButtons = [
       "H2",
       "p",
       "H3",
       "“”",
-      "<>",
       "1.",
       "-",
       "$A",
@@ -82,13 +81,12 @@ test.describe("numbered list", () => {
   test("renders numbered list menu items", async ({ page }) => {
     await page.getByText("-", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const visibleMenuButtons = ["B"];
+    const visibleMenuButtons = [];
     const disabledMenuButtons = [
       "H2",
       "p",
       "H3",
       "“”",
-      "<>",
       "1.",
       "-",
       "$A",

--- a/e2e/menu_items_block/addresses.spec.js
+++ b/e2e/menu_items_block/addresses.spec.js
@@ -9,11 +9,9 @@ test("renders address menu items", async ({ page }) => {
   await page.getByText("$A", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "H2",
     "H3",
     "“”",
-    "<>",
     "$A",
     "$CTA",
     "$C",

--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -9,11 +9,9 @@ test("renders call to action menu items", async ({ page }) => {
   await page.getByText("$CTA", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "H2",
     "H3",
     "“”",
-    "<>",
     "$A",
     "$CTA",
     "$C",

--- a/e2e/menu_items_block/contacts.spec.js
+++ b/e2e/menu_items_block/contacts.spec.js
@@ -9,11 +9,9 @@ test("renders contacts menu items", async ({ page }) => {
   await page.getByText("$C", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "H2",
     "H3",
     "“”",
-    "<>",
     "$A",
     "$CTA",
     "$C",

--- a/e2e/menu_items_block/example_callouts.spec.js
+++ b/e2e/menu_items_block/example_callouts.spec.js
@@ -9,11 +9,9 @@ test("renders example callout menu items", async ({ page }) => {
   await page.getByText("$E", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "H2",
     "H3",
     "“”",
-    "<>",
     "$A",
     "$CTA",
     "$C",

--- a/e2e/menu_items_inline/headings.spec.js
+++ b/e2e/menu_items_inline/headings.spec.js
@@ -10,11 +10,9 @@ test.describe("H2", () => {
     await page.getByText("H2", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
     const visibleMenuButtons = [
-      "B",
       "p",
       "H3",
       "“”",
-      "<>",
       "$A",
       "$CTA",
       "$C",
@@ -87,11 +85,9 @@ test.describe("H3", () => {
     await page.getByText("H3", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
     const visibleMenuButtons = [
-      "B",
       "p",
       "H2",
       "“”",
-      "<>",
       "$A",
       "$CTA",
       "$C",

--- a/e2e/menu_items_inline/information_callouts.spec.js
+++ b/e2e/menu_items_inline/information_callouts.spec.js
@@ -9,12 +9,10 @@ test("renders information callout menu items", async ({ page }) => {
   await page.getByText("^", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "p",
     "H2",
     "H3",
     "“”",
-    "<>",
     "$A",
     "$CTA",
     "$C",

--- a/e2e/menu_items_inline/paragraphs.spec.js
+++ b/e2e/menu_items_inline/paragraphs.spec.js
@@ -8,11 +8,9 @@ test.beforeEach(async ({ page }) => {
 test("should render default menu items", async ({ page }) => {
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "H2",
     "H3",
     "“”",
-    "<>",
     "1.",
     "-",
     "$A",
@@ -50,78 +48,4 @@ test("should render typed paragraph text in the editor when clicking on 'p'", as
   await page.keyboard.type("Testing!\n");
 
   await expect(page.locator("#editor p").getByText("Testing!")).toBeVisible();
-});
-
-test.describe("with bold text", () => {
-  test("should load bold paragraphs from the index file in the editor", async ({
-    page,
-  }) => {
-    await expect(
-      page.locator("#editor p strong").getByText("This is some bold text."),
-    ).toBeVisible();
-  });
-
-  test("should render bold paragraph text in the editor and clear style after new line when clicking on 'B' and typing", async ({
-    page,
-  }) => {
-    await page.getByText("B", { exact: true }).click();
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing bold!\nTesting not bold!\n");
-
-    await expect(
-      page.locator("#editor p strong").getByText("Testing bold!"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor p").getByText("Testing not bold!"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor p strong").getByText("Testing not bold!"),
-    ).not.toBeVisible();
-  });
-
-  test("should toggle bold paragraph text for the same line in the editor when clicking 'B' and typing", async ({
-    page,
-  }) => {
-    await page.getByText("B", { exact: true }).click();
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing bold! ");
-
-    await page.getByText("B", { exact: true }).click();
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type(" and not bold");
-
-    await expect(
-      page.locator("#editor p").getByText("Testing bold! and not bold"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor p strong").getByText("Testing bold!"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor p strong").getByText("and not bold"),
-    ).not.toBeVisible();
-  });
-
-  test("should toggle bold paragraph text when selecting text and clicking 'B'", async ({
-    page,
-  }) => {
-    await page
-      .locator("#editor p strong")
-      .getByText("This is some bold text.")
-      .selectText();
-    await page.getByText("B", { exact: true }).click();
-
-    await expect(
-      page.locator("#editor p strong").getByText("This is some bold text."),
-    ).not.toBeVisible();
-
-    await page
-      .locator("#editor p")
-      .getByText("This is some bold text.")
-      .selectText();
-    await page.getByText("B", { exact: true }).click();
-
-    await expect(
-      page.locator("#editor p strong").getByText("This is some bold text."),
-    ).toBeVisible();
-  });
 });

--- a/e2e/menu_items_inline/warning_callouts.spec.js
+++ b/e2e/menu_items_inline/warning_callouts.spec.js
@@ -9,12 +9,10 @@ test("renders warning callout menu items", async ({ page }) => {
   await page.getByText("%", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
   const visibleMenuButtons = [
-    "B",
     "p",
     "H2",
     "H3",
     "“”",
-    "<>",
     "$A",
     "$CTA",
     "$C",

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <body>
     <div id="content" hidden>
       <p>Hello world, this is the ProseMirror editor.</p>
-      <p><strong>This is some bold text.</strong></p>
       <h2>This is an H2 heading</h2>
       <h3>This is an H3 heading</h3>
       <ol>

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,4 +1,5 @@
 import { MarkdownSerializer } from "prosemirror-markdown";
+import markDefinitions from "./marks.js";
 import nodeDefinitions from "./nodes.js";
 
 const nodesSerializer = Object.fromEntries(
@@ -7,56 +8,11 @@ const nodesSerializer = Object.fromEntries(
     .map((node) => [node.name, node.toGovspeak]),
 );
 
-export const markdownSerializer = new MarkdownSerializer(nodesSerializer, {
-  em: { open: "*", close: "*", mixable: true, expelEnclosingWhitespace: true },
-  strong: {
-    open: "**",
-    close: "**",
-    mixable: true,
-    expelEnclosingWhitespace: true,
-  },
-  link: {
-    open(state, mark, parent, index) {
-      state.inAutolink = isPlainURL(mark, parent, index);
-      return state.inAutolink ? "<" : "[";
-    },
-    close(state, mark, parent, index) {
-      const { inAutolink } = state;
-      state.inAutolink = undefined;
-      return inAutolink
-        ? ">"
-        : "](" +
-            mark.attrs.href.replace(/[()"]/g, "\\$&") +
-            (mark.attrs.title
-              ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"`
-              : "") +
-            ")";
-    },
-    mixable: true,
-  },
-  code: {
-    open(_state, _mark, parent, index) {
-      return backticksFor(parent.child(index), -1);
-    },
-    close(_state, _mark, parent, index) {
-      return backticksFor(parent.child(index - 1), 1);
-    },
-    escape: false,
-  },
-});
+const marksSerializerSpec = Object.fromEntries(
+  markDefinitions.map((mark) => [mark.name, mark.serializerSpec]),
+);
 
-
-function isPlainURL(link, parent, index) {
-  if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false;
-  const content = parent.child(index);
-  if (
-    !content.isText ||
-    content.text !== link.attrs.href ||
-    content.marks[content.marks.length - 1] !== link
-  )
-    return false;
-  return (
-    index === parent.childCount - 1 ||
-    !link.isInSet(parent.child(index + 1).marks)
-  );
-}
+export const markdownSerializer = new MarkdownSerializer(
+  nodesSerializer,
+  marksSerializerSpec,
+);

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,81 +1,10 @@
 import { MarkdownSerializer } from "prosemirror-markdown";
-import customNodes from "./nodes.js";
+import nodeDefinitions from "./nodes.js";
 
-const defaultNodesSerializer = {
-  blockquote(state, node) {
-    state.wrapBlock("> ", null, node, () => state.renderContent(node));
-  },
-  code_block(state, node) {
-    // Make sure the front matter fences are longer than any dash sequence within it
-    const backticks = node.textContent.match(/`{3,}/gm);
-    const fence = backticks ? backticks.sort().slice(-1)[0] + "`" : "```";
-
-    state.write(fence + (node.attrs.params || "") + "\n");
-    state.text(node.textContent, false);
-    // Add a newline to the current content before adding closing marker
-    state.write("\n");
-    state.write(fence);
-    state.closeBlock(node);
-  },
-  heading(state, node) {
-    state.write(state.repeat("#", node.attrs.level) + " ");
-    state.renderInline(node, false);
-    state.closeBlock(node);
-  },
-  horizontal_rule(state, node) {
-    state.write(node.attrs.markup || "---");
-    state.closeBlock(node);
-  },
-  bullet_list(state, node) {
-    state.renderList(node, "  ", () => (node.attrs.bullet || "*") + " ");
-  },
-  ordered_list(state, node) {
-    const start = node.attrs.order || 1;
-    const maxW = String(start + node.childCount - 1).length;
-    const space = state.repeat(" ", maxW + 2);
-    state.renderList(node, space, (i) => {
-      const nStr = String(start + i);
-      return state.repeat(" ", maxW - nStr.length) + nStr + ". ";
-    });
-  },
-  list_item(state, node) {
-    state.renderContent(node);
-  },
-  paragraph(state, node) {
-    state.renderInline(node);
-    state.closeBlock(node);
-  },
-  image(state, node) {
-    state.write(
-      "![" +
-        state.esc(node.attrs.alt || "") +
-        "](" +
-        node.attrs.src.replace(/[()]/g, "\\$&") +
-        (node.attrs.title
-          ? ' "' + node.attrs.title.replace(/"/g, '\\"') + '"'
-          : "") +
-        ")",
-    );
-  },
-  hard_break(state, node, parent, index) {
-    for (let i = index + 1; i < parent.childCount; i++)
-      if (parent.child(i).type !== node.type) {
-        state.write("\\\n");
-        return;
-      }
-  },
-  text(state, node) {
-    state.text(node.text, !state.inAutolink);
-  },
-};
-
-const customNodesSerializer = Object.fromEntries(
-  customNodes.map((node) => [node.name, node.toGovspeak]),
-);
-
-const nodesSerializer = Object.assign(
-  defaultNodesSerializer,
-  customNodesSerializer,
+const nodesSerializer = Object.fromEntries(
+  nodeDefinitions
+    .filter((node) => typeof node.toGovspeak !== "undefined")
+    .map((node) => [node.name, node.toGovspeak]),
 );
 
 export const markdownSerializer = new MarkdownSerializer(nodesSerializer, {
@@ -116,17 +45,6 @@ export const markdownSerializer = new MarkdownSerializer(nodesSerializer, {
   },
 });
 
-function backticksFor(node, side) {
-  const ticks = /`+/g;
-  let m;
-  let len = 0;
-  if (node.isText)
-    while (m === ticks.exec(node.text)) len = Math.max(len, m[0].length);
-  let result = len > 0 && side > 0 ? " `" : "`";
-  for (let i = 0; i < len; i++) result += "`";
-  if (len > 0 && side < 0) result += " ";
-  return result;
-}
 
 function isPlainURL(link, parent, index) {
   if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false;

--- a/lib/marks.js
+++ b/lib/marks.js
@@ -1,0 +1,3 @@
+import * as link from "./marks/link.js";
+
+export default [link];

--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -1,0 +1,58 @@
+export const name = "link";
+
+export const schema = {
+  attrs: {
+    href: {},
+    title: { default: null },
+  },
+  inclusive: false,
+  parseDOM: [
+    {
+      tag: "a[href]",
+      getAttrs(dom) {
+        return {
+          href: dom.getAttribute("href"),
+          title: dom.getAttribute("title"),
+        };
+      },
+    },
+  ],
+  toDOM(node) {
+    return ["a", node.attrs];
+  },
+};
+
+export const serializerSpec = {
+  open(state, mark, parent, index) {
+    state.inAutolink = isPlainURL(mark, parent, index);
+    return state.inAutolink ? "<" : "[";
+  },
+  close(state, mark, parent, index) {
+    const { inAutolink } = state;
+    state.inAutolink = undefined;
+    return inAutolink
+      ? ">"
+      : "](" +
+          mark.attrs.href.replace(/[()"]/g, "\\$&") +
+          (mark.attrs.title
+            ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"`
+            : "") +
+          ")";
+  },
+  mixable: true,
+};
+
+function isPlainURL(link, parent, index) {
+  if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false;
+  const content = parent.child(index);
+  if (
+    !content.isText ||
+    content.text !== link.attrs.href ||
+    content.marks[content.marks.length - 1] !== link
+  )
+    return false;
+  return (
+    index === parent.childCount - 1 ||
+    !link.isInSet(parent.child(index + 1).marks)
+  );
+}

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1,15 +1,33 @@
 import * as address from "./nodes/address.js";
+import * as blockquote from "./nodes/blockquote.js";
+import * as bullet_list from "./nodes/bullet_list.js";
 import * as callToAction from "./nodes/call_to_action.js";
 import * as contact from "./nodes/contact.js";
+import * as doc from "./nodes/doc.js";
 import * as exampleCallout from "./nodes/example_callout.js";
+import * as hard_break from "./nodes/hard_break.js";
+import * as heading from "./nodes/heading.js";
 import * as informationCallout from "./nodes/information_callout.js";
+import * as list_item from "./nodes/list_item.js";
+import * as ordered_list from "./nodes/ordered_list.js";
+import * as paragraph from "./nodes/paragraph.js";
+import * as text from "./nodes/text.js";
 import * as warningCallout from "./nodes/warning_callout.js";
 
 export default [
+  paragraph, // Paragraph must be first to be the default
   address,
+  blockquote,
+  bullet_list,
   callToAction,
   contact,
+  doc,
   exampleCallout,
+  hard_break,
+  heading,
   informationCallout,
+  list_item,
+  ordered_list,
+  text,
   warningCallout,
 ];

--- a/lib/nodes/blockquote.js
+++ b/lib/nodes/blockquote.js
@@ -1,0 +1,26 @@
+import { wrapIn } from "prosemirror-commands";
+
+export const name = "blockquote";
+
+export const schema = {
+  content: "block+",
+  group: "block",
+  parseDOM: [{ tag: "blockquote" }],
+  toDOM() {
+    return ["blockquote", 0];
+  },
+};
+
+export const buildMenuItemCommand = (nodeSchema) => wrapIn(nodeSchema);
+
+export const buildMenuItemDom = () => {
+  const button = document.createElement("button");
+  button.className = "govuk-button govuk-button--secondary";
+  button.title = "Blockquote";
+  button.textContent = "“”";
+  button.type = "button";
+  return button;
+};
+export const toGovspeak = (state, node) => {
+  state.wrapBlock("> ", null, node, () => state.renderContent(node));
+};

--- a/lib/nodes/bullet_list.js
+++ b/lib/nodes/bullet_list.js
@@ -1,0 +1,32 @@
+import { wrapIn } from "prosemirror-commands";
+
+export const name = "bullet_list";
+
+export const schema = {
+  content: "list_item+",
+  group: "block",
+  attrs: { tight: { default: false } },
+  parseDOM: [
+    {
+      tag: "ul",
+      getAttrs: (dom) => ({ tight: dom.hasAttribute("data-tight") }),
+    },
+  ],
+  toDOM(node) {
+    return ["ul", { "data-tight": node.attrs.tight ? "true" : null }, 0];
+  },
+};
+
+export const buildMenuItemCommand = (nodeSchema) => wrapIn(nodeSchema);
+
+export const buildMenuItemDom = () => {
+  const button = document.createElement("button");
+  button.className = "govuk-button govuk-button--secondary";
+  button.title = "Bullet list";
+  button.textContent = "-";
+  button.type = "button";
+  return button;
+};
+export const toGovspeak = (state, node) => {
+  state.renderList(node, "  ", () => (node.attrs.bullet || "*") + " ");
+};

--- a/lib/nodes/doc.js
+++ b/lib/nodes/doc.js
@@ -1,0 +1,5 @@
+export const name = "doc";
+
+export const schema = {
+  content: "block+",
+};

--- a/lib/nodes/hard_break.js
+++ b/lib/nodes/hard_break.js
@@ -1,0 +1,18 @@
+export const name = "hard_break";
+
+export const schema = {
+  inline: true,
+  group: "inline",
+  selectable: false,
+  parseDOM: [{ tag: "br" }],
+  toDOM() {
+    return ["br"];
+  },
+};
+export const toGovspeak = (state, node, parent, index) => {
+  for (let i = index + 1; i < parent.childCount; i++)
+    if (parent.child(i).type !== node.type) {
+      state.write("\\\n");
+      return;
+    }
+};

--- a/lib/nodes/heading.js
+++ b/lib/nodes/heading.js
@@ -1,0 +1,23 @@
+export const name = "heading";
+
+export const schema = {
+  attrs: { level: { default: 2 } },
+  content: "text*",
+  group: "block",
+  defining: true,
+  parseDOM: [
+    { tag: "h2", attrs: { level: 2 } },
+    { tag: "h3", attrs: { level: 3 } },
+    { tag: "h4", attrs: { level: 4 } },
+    { tag: "h5", attrs: { level: 5 } },
+    { tag: "h6", attrs: { level: 6 } },
+  ],
+  toDOM(node) {
+    return ["h" + node.attrs.level, 0];
+  },
+};
+export const toGovspeak = (state, node) => {
+  state.write(state.repeat("#", node.attrs.level) + " ");
+  state.renderInline(node, false);
+  state.closeBlock(node);
+};

--- a/lib/nodes/list_item.js
+++ b/lib/nodes/list_item.js
@@ -1,0 +1,14 @@
+export const name = "list_item";
+
+export const schema = {
+  content: "paragraph block*",
+  defining: true,
+  parseDOM: [{ tag: "li" }],
+  toDOM() {
+    return ["li", 0];
+  },
+};
+
+export const toGovspeak = (state, node) => {
+  state.renderContent(node);
+};

--- a/lib/nodes/ordered_list.js
+++ b/lib/nodes/ordered_list.js
@@ -1,0 +1,44 @@
+import { wrapIn } from "prosemirror-commands";
+
+export const name = "ordered_list";
+
+export const schema = {
+  content: "list_item+",
+  group: "block",
+  attrs: { order: { default: 1 } },
+  parseDOM: [
+    {
+      tag: "ol",
+      getAttrs(dom) {
+        return {
+          order: dom.hasAttribute("start") ? +dom.getAttribute("start") : 1,
+        };
+      },
+    },
+  ],
+  toDOM(node) {
+    return node.attrs.order === 1
+      ? ["ol", 0]
+      : ["ol", { start: node.attrs.order }, 0];
+  },
+};
+
+export const buildMenuItemCommand = (nodeSchema) => wrapIn(nodeSchema);
+
+export const buildMenuItemDom = () => {
+  const button = document.createElement("button");
+  button.className = "govuk-button govuk-button--secondary";
+  button.title = "Ordered list";
+  button.textContent = "1.";
+  button.type = "button";
+  return button;
+};
+export const toGovspeak = (state, node) => {
+  const start = node.attrs.order || 1;
+  const maxW = String(start + node.childCount - 1).length;
+  const space = state.repeat(" ", maxW + 2);
+  state.renderList(node, space, (i) => {
+    const nStr = String(start + i);
+    return state.repeat(" ", maxW - nStr.length) + nStr + ". ";
+  });
+};

--- a/lib/nodes/paragraph.js
+++ b/lib/nodes/paragraph.js
@@ -1,0 +1,27 @@
+import { setBlockType } from "prosemirror-commands";
+
+export const name = "paragraph";
+
+export const schema = {
+  content: "inline*",
+  group: "block",
+  parseDOM: [{ tag: "p" }],
+  toDOM() {
+    return ["p", 0];
+  },
+};
+
+export const buildMenuItemCommand = (nodeSchema) => setBlockType(nodeSchema);
+
+export const buildMenuItemDom = () => {
+  const button = document.createElement("button");
+  button.className = "govuk-button govuk-button--secondary";
+  button.title = "Paragraph";
+  button.textContent = "p";
+  button.type = "button";
+  return button;
+};
+export const toGovspeak = (state, node) => {
+  state.renderInline(node);
+  state.closeBlock(node);
+};

--- a/lib/nodes/text.js
+++ b/lib/nodes/text.js
@@ -1,0 +1,8 @@
+export const name = "text";
+
+export const schema = {
+  group: "inline",
+};
+export const toGovspeak = (state, node) => {
+  state.text(node.text, !state.inAutolink);
+};

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,11 +1,13 @@
 import { exampleSetup } from "prosemirror-example-setup";
 import { inputRules } from "prosemirror-inputrules";
 import { Plugin } from "prosemirror-state";
-import customNodes from "./nodes";
+import nodeDefinitions from "./nodes";
 import menu from "./plugins/menu";
 
 const customInputRules = (schema) => {
-  const rules = customNodes.flatMap((node) => node.inputRules(schema));
+  const rules = nodeDefinitions
+    .filter((node) => typeof node.inputRules !== "undefined")
+    .flatMap((node) => node.inputRules(schema));
   return inputRules({ rules });
 };
 

--- a/lib/plugins/menu-plugin-view.js
+++ b/lib/plugins/menu-plugin-view.js
@@ -63,9 +63,12 @@ export default class MenuPluginView {
       dom.disabled = !active;
     });
 
-    if (!focusableButton.disabled) return;
+    if (!focusableButton || !focusableButton.disabled) return;
 
     const buttonToFocus = this.dom.querySelector("button:not(:disabled)");
+
+    if (!buttonToFocus) return;
+
     focusableButton.setAttribute("tabindex", -1);
     buttonToFocus.setAttribute("tabindex", 0);
   }

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -1,55 +1,32 @@
-import { toggleMark, setBlockType, wrapIn } from "prosemirror-commands";
-import customNodes from "../nodes.js";
+import { setBlockType } from "prosemirror-commands";
+import nodeDefinitions from "../nodes.js";
 import { Plugin } from "prosemirror-state";
 import MenuPluginView from "./menu-plugin-view";
 
-// Helper function to create menu buttons
-function button(text, name) {
-  const button = document.createElement("button");
-  button.className = "govuk-button govuk-button--secondary";
-  button.title = name;
-  button.textContent = text;
-  button.type = "button";
-  return button;
-}
-
 // Create an icon for a heading at the given level
 function headingButton(schema, level) {
+  const button = document.createElement("button");
+  button.className = "govuk-button govuk-button--secondary";
+  button.title = "heading";
+  button.textContent = "H" + level;
+  button.type = "button";
+
   return {
     command: setBlockType(schema.nodes.heading, { level }),
-    dom: button("H" + level, "heading"),
+    dom: button,
   };
 }
 
 function items(schema) {
   return [
-    { command: toggleMark(schema.marks.strong), dom: button("B", "Strong") },
-    {
-      command: setBlockType(schema.nodes.paragraph),
-      dom: button("p", "Paragraph"),
-    },
     headingButton(schema, 2),
     headingButton(schema, 3),
-    {
-      command: wrapIn(schema.nodes.blockquote),
-      dom: button("“”", "Blockquote"),
-    },
-    {
-      command: setBlockType(schema.nodes.code_block),
-      dom: button("<>", "Code block"),
-    },
-    {
-      command: wrapIn(schema.nodes.ordered_list),
-      dom: button("1.", "Ordered list"),
-    },
-    {
-      command: wrapIn(schema.nodes.bullet_list),
-      dom: button("-", "Bullet list"),
-    },
-    ...customNodes.map((node) => ({
-      command: node.buildMenuItemCommand(schema.nodes[node.name]),
-      dom: node.buildMenuItemDom(),
-    })),
+    ...nodeDefinitions
+      .filter((node) => typeof node.buildMenuItemCommand !== "undefined")
+      .map((node) => ({
+        command: node.buildMenuItemCommand(schema.nodes[node.name]),
+        dom: node.buildMenuItemDom(),
+      })),
   ];
 }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,13 +1,14 @@
 import { Schema } from "prosemirror-model";
-import { schema as basicSchema } from "prosemirror-markdown";
 import nodeDefinitions from "./nodes";
+import markDefinitions from "./marks";
 
 const nodes = Object.fromEntries(
   nodeDefinitions.map((node) => [node.name, node.schema]),
 );
 
-// Remove em from the schema as it is not supported in Govspeak
-const marks = basicSchema.spec.marks.remove("em");
+const marks = Object.fromEntries(
+  markDefinitions.map((mark) => [mark.name, mark.schema]),
+);
 
 export default new Schema({
   nodes,

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,19 +1,10 @@
-import { addListNodes } from "prosemirror-schema-list";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-markdown";
-import customNodes from "./nodes";
+import nodeDefinitions from "./nodes";
 
-// Use basic schema which roughly corresponds to the CommonMark schema
-let nodes = basicSchema.spec.nodes;
-
-// Mix the nodes from prosemirror-schema-list into the basic schema to
-// create a schema with list support.
-nodes = addListNodes(nodes, "paragraph block*", "block");
-
-// Add node schemas from the "nodes" directory
-customNodes.forEach((node) => {
-  nodes = nodes.addToEnd(node.name, node.schema);
-});
+const nodes = Object.fromEntries(
+  nodeDefinitions.map((node) => [node.name, node.schema]),
+);
 
 // Remove em from the schema as it is not supported in Govspeak
 const marks = basicSchema.spec.marks.remove("em");

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-markdown": "^1.11.2",
     "prosemirror-model": "^1.19.3",
-    "prosemirror-schema-basic": "^1.2.2",
-    "prosemirror-schema-list": "^1.3.0",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.8.0",
     "prosemirror-view": "^1.32.1"


### PR DESCRIPTION
# What
- Copy node schema definitions from the prosemirror markdown codebase to the node definitions defined in visual editor
- Lists are copied from the `prosemirror-schema-list`
- Exclude code blocks, horizontal rules and h1s from the schema
- Copy the link mark schema definition from the prosemirror markdown codebase to a new marks directory
- Exclude bold, em and inline code blocks
- Update the menu plugin view to handle having no focusable buttons
- Remove references to bold in the tests

# Why
- Makes the way in which all nodes are defined consistent which will make future changes easier
- Brings marks in line with nodes which will make future changes easier
- Removes markdown features that we will not be supporting

https://trello.com/c/2LpuXUTH/2521-exclude-bold-emphasis-and-code-blocks-h1-from-schema