### PR TITLE
Restrict contents of headers and blockquotes

### DIFF
--- a/e2e/menu_items_block/blockquote.spec.js
+++ b/e2e/menu_items_block/blockquote.spec.js
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { VISUAL_EDITOR_URL } from "../helpers/constants.js";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(VISUAL_EDITOR_URL);
+});
+
+test("renders blockquote menu items", async ({ page }) => {
+  await page.getByText("“”", { exact: true }).click();
+  await expect(page.locator(".menubar")).toBeVisible();
+  const visibleMenuButtons = [];
+  const disabledMenuButtons = [
+    "H2",
+    "H3",
+    "p",
+    "“”",
+    "$A",
+    "$CTA",
+    "$C",
+    "$E",
+    "^",
+    "%",
+    "1.",
+    "-",
+  ];
+
+  for (const button of visibleMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeDisabled();
+});
+
+test("should render blockquote in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
+
+  await page.getByText("New line").click();
+  await page.getByText("“”", { exact: true }).click();
+  await page.getByText("New line").selectText();
+  await page.keyboard.type(
+    "Blockquote line 1\nBlockquote line 2\n\nNot blockquote\n",
+  );
+
+  await expect(
+    page.locator("#editor blockquote").getByText("Blockquote line 1"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor blockquote").getByText("Blockquote line 2"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor blockquote").getByText("Not blockquote"),
+  ).not.toBeVisible();
+});
+
+test("should toggle blockquote for existing paragraph line", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page.getByText("“”", { exact: true }).click();
+  await expect(
+    page.locator("#editor blockquote").getByText("Testing paragraph"),
+  ).toBeVisible();
+});

--- a/lib/nodes/blockquote.js
+++ b/lib/nodes/blockquote.js
@@ -3,7 +3,7 @@ import { wrapIn } from "prosemirror-commands";
 export const name = "blockquote";
 
 export const schema = {
-  content: "block+",
+  content: "paragraph+",
   group: "block",
   parseDOM: [{ tag: "blockquote" }],
   toDOM() {

--- a/lib/nodes/heading.js
+++ b/lib/nodes/heading.js
@@ -4,6 +4,7 @@ export const schema = {
   attrs: { level: { default: 2 } },
   content: "text*",
   group: "block",
+  marks: "",
   defining: true,
   parseDOM: [
     { tag: "h2", attrs: { level: 2 } },


### PR DESCRIPTION
# What
- Exclude all marks from headings
- Restrict blockquotes to only allow paragraphs as content
- Introduce testing for blockquotes

# Why
- To better match the behaviour of the govspeak gem and content recommendations
- https://docs.google.com/spreadsheets/d/1aPI7IOllIjqCIiCIUM3qDZy-wY0hBurwoTp01_XGuzk/edit#gid=1398418881
- https://trello.com/c/A7EgXpZl/2522-restrict-contents-of-headers-links-blockquotes-and-addresses-to-text