### PR TITLE
Prevent heading usage inside call to action nodes

### DIFF
--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -88,3 +88,15 @@ test("should allow embedding of other content", async ({ page }) => {
       .getByText("Testing call to action"),
   ).toBeVisible();
 });
+
+test("should not allow headings as a child node", async ({ page }) => {
+  await page.getByText("$CTA", { exact: true }).click();
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing call to action\n\n");
+
+  await page
+    .locator("#editor .call-to-action")
+    .getByText("Testing call to action")
+    .click();
+  await expect(page.getByText("H3", { exact: true })).toBeDisabled();
+});

--- a/lib/nodes/doc.js
+++ b/lib/nodes/doc.js
@@ -1,5 +1,5 @@
 export const name = "doc";
 
 export const schema = {
-  content: "block+",
+  content: "(block|heading)+",
 };

--- a/lib/nodes/heading.js
+++ b/lib/nodes/heading.js
@@ -3,7 +3,6 @@ export const name = "heading";
 export const schema = {
   attrs: { level: { default: 2 } },
   content: "text*",
-  group: "block",
   marks: "",
   defining: true,
   parseDOM: [


### PR DESCRIPTION
GOV.UK govspeak usage guidance prohibits the use of headings inside call to action blocks.

Call to action blocks can have any other type of block nested inside them at present, so we remove the heading node from the "block" group and include them as a separate group in the document schema definition. The alternative would have been to define a new group for all blocks other than headings, which felt less maintainable.

Trello: https://trello.com/c/dY5Fz1PN