### PR TITLE
Prevent heading usage in example callouts

### DIFF
--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -88,3 +88,15 @@ test("should allow embedding of other content", async ({ page }) => {
       .getByText("Testing call to action"),
   ).toBeVisible();
 });
+
+test("should not allow headings as a child node", async ({ page }) => {
+  await page.getByText("$CTA", { exact: true }).click();
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing call to action\n\n");
+
+  await page
+    .locator("#editor .call-to-action")
+    .getByText("Testing call to action")
+    .click();
+  await expect(page.getByText("H3", { exact: true })).toBeDisabled();
+});

--- a/e2e/menu_items_block/example_callouts.spec.js
+++ b/e2e/menu_items_block/example_callouts.spec.js
@@ -88,3 +88,15 @@ test("should allow embedding of other content", async ({ page }) => {
       .getByText("Testing example callout"),
   ).toBeVisible();
 });
+
+test("should not allow headings as a child node", async ({ page }) => {
+  await page.getByText("$E", { exact: true }).click();
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing example callout\n\n");
+
+  await page
+    .locator("#editor .example")
+    .getByText("Testing example callout")
+    .click();
+  await expect(page.getByText("H3", { exact: true })).toBeDisabled();
+});

--- a/lib/nodes/doc.js
+++ b/lib/nodes/doc.js
@@ -1,5 +1,5 @@
 export const name = "doc";
 
 export const schema = {
-  content: "block+",
+  content: "(block|heading)+",
 };

--- a/lib/nodes/heading.js
+++ b/lib/nodes/heading.js
@@ -3,7 +3,6 @@ export const name = "heading";
 export const schema = {
   attrs: { level: { default: 2 } },
   content: "text*",
-  group: "block",
   marks: "",
   defining: true,
   parseDOM: [


### PR DESCRIPTION
Only a regression test required here, as the actual work was done in #38 , which this PR depends upon

Trello: https://trello.com/c/dY5Fz1PN