### PR TITLE
Upgrade to govuk-dependabot-merger v2

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,6 +1,9 @@
-api_version: 1
-auto_merge:
+api_version: 2
+defaults:
+  auto_merge: false
+overrides:
   - dependency: govuk_publishing_components
+    auto_merge: true
     allowed_semver_bumps:
       - patch
       - minor


### PR DESCRIPTION
Retain the old allow-list style behaviour for now, just auto merging updates to govuk_publishing_components, as we're lacking security scans and code coverage information stipulated by RFC-167 before we can consider auto-merging all dependencies by default.

Trello: https://trello.com/c/0FUL9Cv7/2541-upgrade-our-publishing-apps-to-govuk-dependabot-merger-v2