### PR TITLE
Make tests for editor toolbar state reflect intended behaviour

### DIFF
--- a/e2e/menu_items_block/addresses.spec.js
+++ b/e2e/menu_items_block/addresses.spec.js
@@ -5,12 +5,12 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders address menu items", async ({ page }) => {
+test("renders address menu items with expected disabled states", async ({
+  page,
+}) => {
   await page.getByText("$A", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
-    "H2",
-    "H3",
+  const enabledMenuButtons = [
     "“”",
     "$A",
     "$CTA",
@@ -21,10 +21,10 @@ test("renders address menu items", async ({ page }) => {
     "1.",
     "-",
   ];
-  const disabledMenuButtons = ["p"];
+  const disabledMenuButtons = ["p", "H2", "H3"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_block/blockquote.spec.js
+++ b/e2e/menu_items_block/blockquote.spec.js
@@ -5,10 +5,12 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders blockquote menu items", async ({ page }) => {
+test("renders blockquote menu items with expected disabled states", async ({
+  page,
+}) => {
   await page.getByText("“”", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [];
+  const enabledMenuButtons = [];
   const disabledMenuButtons = [
     "H2",
     "H3",
@@ -24,8 +26,8 @@ test("renders blockquote menu items", async ({ page }) => {
     "-",
   ];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -5,12 +5,12 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders call to action menu items", async ({ page }) => {
+test("renders call to action menu items with expected disabled state", async ({
+  page,
+}) => {
   await page.getByText("$CTA", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
-    "H2",
-    "H3",
+  const enabledMenuButtons = [
     "“”",
     "$A",
     "$CTA",
@@ -21,10 +21,10 @@ test("renders call to action menu items", async ({ page }) => {
     "1.",
     "-",
   ];
-  const disabledMenuButtons = ["p"];
+  const disabledMenuButtons = ["p", "H2", "H3"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });
@@ -87,16 +87,4 @@ test("should allow embedding of other content", async ({ page }) => {
       .locator("#editor .call-to-action .call-to-action")
       .getByText("Testing call to action"),
   ).toBeVisible();
-});
-
-test("should not allow headings as a child node", async ({ page }) => {
-  await page.getByText("$CTA", { exact: true }).click();
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing call to action\n\n");
-
-  await page
-    .locator("#editor .call-to-action")
-    .getByText("Testing call to action")
-    .click();
-  await expect(page.getByText("H3", { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_block/contacts.spec.js
+++ b/e2e/menu_items_block/contacts.spec.js
@@ -5,12 +5,12 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders contacts menu items", async ({ page }) => {
+test("renders contacts menu items with expected disabled states", async ({
+  page,
+}) => {
   await page.getByText("$C", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
-    "H2",
-    "H3",
+  const enabledMenuButtons = [
     "“”",
     "$A",
     "$CTA",
@@ -21,10 +21,10 @@ test("renders contacts menu items", async ({ page }) => {
     "1.",
     "-",
   ];
-  const disabledMenuButtons = ["p"];
+  const disabledMenuButtons = ["p", "H2", "H3"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_block/example_callouts.spec.js
+++ b/e2e/menu_items_block/example_callouts.spec.js
@@ -5,12 +5,12 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders example callout menu items", async ({ page }) => {
+test("renders example callout menu items with expected disabled state", async ({
+  page,
+}) => {
   await page.getByText("$E", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
-    "H2",
-    "H3",
+  const enabledMenuButtons = [
     "“”",
     "$A",
     "$CTA",
@@ -21,10 +21,10 @@ test("renders example callout menu items", async ({ page }) => {
     "1.",
     "-",
   ];
-  const disabledMenuButtons = ["p"];
+  const disabledMenuButtons = ["p", "H2", "H3"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });
@@ -87,16 +87,4 @@ test("should allow embedding of other content", async ({ page }) => {
       .locator("#editor .example .example")
       .getByText("Testing example callout"),
   ).toBeVisible();
-});
-
-test("should not allow headings as a child node", async ({ page }) => {
-  await page.getByText("$E", { exact: true }).click();
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing example callout\n\n");
-
-  await page
-    .locator("#editor .example")
-    .getByText("Testing example callout")
-    .click();
-  await expect(page.getByText("H3", { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_inline/headings.spec.js
+++ b/e2e/menu_items_inline/headings.spec.js
@@ -9,21 +9,20 @@ test.describe("H2", () => {
   test("renders H2 menu items", async ({ page }) => {
     await page.getByText("H2", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const visibleMenuButtons = [
-      "p",
-      "H3",
+    const enabledMenuButtons = ["p", "H3", "^", "%"];
+    const disabledMenuButtons = [
+      "H2",
+      "1.",
+      "-",
       "“”",
       "$A",
       "$CTA",
       "$C",
       "$E",
-      "^",
-      "%",
     ];
-    const disabledMenuButtons = ["H2", "1.", "-"];
 
-    for (const button of visibleMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeVisible();
+    for (const button of enabledMenuButtons)
+      await expect(page.getByText(button, { exact: true })).toBeEnabled();
     for (const button of disabledMenuButtons)
       await expect(page.getByText(button, { exact: true })).toBeDisabled();
   });
@@ -81,21 +80,22 @@ test.describe("H2", () => {
 });
 
 test.describe("H3", () => {
-  test("renders H3 menu items", async ({ page }) => {
+  test("renders H3 menu items with expected disabled state", async ({
+    page,
+  }) => {
     await page.getByText("H3", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const visibleMenuButtons = [
-      "p",
-      "H2",
+    const visibleMenuButtons = ["p", "H2", "^", "%"];
+    const disabledMenuButtons = [
+      "H3",
+      "1.",
+      "-",
       "“”",
       "$A",
       "$CTA",
       "$C",
       "$E",
-      "^",
-      "%",
     ];
-    const disabledMenuButtons = ["H3", "1.", "-"];
 
     for (const button of visibleMenuButtons)
       await expect(page.getByText(button, { exact: true })).toBeVisible();

--- a/e2e/menu_items_inline/information_callouts.spec.js
+++ b/e2e/menu_items_inline/information_callouts.spec.js
@@ -5,24 +5,16 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders information callout menu items", async ({ page }) => {
+test("renders information callout menu items with expected disabled states", async ({
+  page,
+}) => {
   await page.getByText("^", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
-    "p",
-    "H2",
-    "H3",
-    "“”",
-    "$A",
-    "$CTA",
-    "$C",
-    "$E",
-    "%",
-  ];
-  const disabledMenuButtons = ["^", "1.", "-"];
+  const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$C", "$E", "%"];
+  const disabledMenuButtons = ["“”", "^", "1.", "-"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_inline/paragraphs.spec.js
+++ b/e2e/menu_items_inline/paragraphs.spec.js
@@ -5,9 +5,11 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("should render default menu items", async ({ page }) => {
+test("should render default menu items with expected disabled states", async ({
+  page,
+}) => {
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
+  const enabledMenuButtons = [
     "H2",
     "H3",
     "“”",
@@ -22,8 +24,8 @@ test("should render default menu items", async ({ page }) => {
   ];
   const disabledMenuButtons = ["p"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });

--- a/e2e/menu_items_inline/warning_callouts.spec.js
+++ b/e2e/menu_items_inline/warning_callouts.spec.js
@@ -5,24 +5,16 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders warning callout menu items", async ({ page }) => {
+test("renders warning callout menu items with expected disabled states", async ({
+  page,
+}) => {
   await page.getByText("%", { exact: true }).click();
   await expect(page.locator(".menubar")).toBeVisible();
-  const visibleMenuButtons = [
-    "p",
-    "H2",
-    "H3",
-    "“”",
-    "$A",
-    "$CTA",
-    "$C",
-    "$E",
-    "^",
-  ];
-  const disabledMenuButtons = ["%", "1.", "-"];
+  const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$C", "$E", "^"];
+  const disabledMenuButtons = ["“”", "%", "1.", "-"];
 
-  for (const button of visibleMenuButtons)
-    await expect(page.getByText(button, { exact: true })).toBeVisible();
+  for (const button of enabledMenuButtons)
+    await expect(page.getByText(button, { exact: true })).toBeEnabled();
   for (const button of disabledMenuButtons)
     await expect(page.getByText(button, { exact: true })).toBeDisabled();
 });


### PR DESCRIPTION
These tests are intended to ensure that we have the correct toolbar elements enabled or disabled for each node context.

Because they were only testing that toolbar elements were visible, we were not asserting that some toolbar elements were disabled. Asserting that certain toolbar elements are disabled is a valuable property of the test suite, because that is the only way we can confirm that the Prosemirror schema is configured as intended.

This commit solves this problem by asserting that each toolbar element is either enabled or disabled, as appropriate.

Trello: https://trello.com/c/Pcll8L2Z