### PR TITLE
Restrict contents of contact block and lists

### DIFF
--- a/e2e/menu_items_block/contacts.spec.js
+++ b/e2e/menu_items_block/contacts.spec.js
@@ -10,18 +10,21 @@ test.fixme(
   async ({ page }) => {
     await page.getByText("$C", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [
+    const enabledMenuButtons = [];
+    const disabledMenuButtons = [
+      "H2",
+      "p",
+      "H3",
       "“”",
+      "1.",
+      "-",
       "$A",
       "$CTA",
       "$C",
       "$E",
       "^",
       "%",
-      "1.",
-      "-",
     ];
-    const disabledMenuButtons = ["p", "H2", "H3"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByText(button, { exact: true })).toBeEnabled();
@@ -67,7 +70,6 @@ test.fixme(
   async ({ page }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("Testing paragraph\n");
-
     await page.locator("#editor p").getByText("Testing paragraph").click();
     await page.getByText("$C", { exact: true }).click();
     await expect(
@@ -75,15 +77,3 @@ test.fixme(
     ).toBeVisible();
   },
 );
-
-test.fixme("should allow embedding of other content", async ({ page }) => {
-  await page.getByText("$C", { exact: true }).click();
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing contact\n\n");
-
-  await page.locator("#editor .contact").getByText("Testing contact").click();
-  await page.getByText("$C", { exact: true }).click();
-  await expect(
-    page.locator("#editor .contact .contact").getByText("Testing contact"),
-  ).toBeVisible();
-});

--- a/e2e/menu_items_inline/information_callouts.spec.js
+++ b/e2e/menu_items_inline/information_callouts.spec.js
@@ -10,9 +10,8 @@ test.fixme(
   async ({ page }) => {
     await page.getByText("^", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$C", "$E", "%"];
-    const disabledMenuButtons = ["“”", "^", "1.", "-"];
-
+    const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$E", "%"];
+    const disabledMenuButtons = ["“”", "^", "1.", "-", "$C"];
     for (const button of enabledMenuButtons)
       await expect(page.getByText(button, { exact: true })).toBeEnabled();
     for (const button of disabledMenuButtons)

--- a/e2e/menu_items_inline/warning_callouts.spec.js
+++ b/e2e/menu_items_inline/warning_callouts.spec.js
@@ -10,8 +10,8 @@ test.fixme(
   async ({ page }) => {
     await page.getByText("%", { exact: true }).click();
     await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$C", "$E", "^"];
-    const disabledMenuButtons = ["“”", "%", "1.", "-"];
+    const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$E", "^"];
+    const disabledMenuButtons = ["“”", "%", "1.", "-", "$C"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByText(button, { exact: true })).toBeEnabled();

--- a/lib/nodes/contact.js
+++ b/lib/nodes/contact.js
@@ -3,7 +3,7 @@ import { wrappingInputRule } from "prosemirror-inputrules";
 export const name = "contact";
 
 export const schema = {
-  content: "block+",
+  content: "paragraph+",
   group: "block",
   defining: true,
   parseDOM: [{ tag: `div.contact[role="contact"][aria-label="Contact"]` }],

--- a/lib/nodes/list_item.js
+++ b/lib/nodes/list_item.js
@@ -1,7 +1,7 @@
 export const name = "list_item";
 
 export const schema = {
-  content: "paragraph block*",
+  content: "paragraph",
   defining: true,
   parseDOM: [{ tag: "li" }],
   toDOM() {


### PR DESCRIPTION
Use the schema to restrict contents of contacts to text only and prevent list nesting.

https://trello.com/c/iIKHvSUp/2524-adjust-all-list-types-contact-blocks-information-and-warning-callouts-to-only-allow-text-and-links-as-content