### PR TITLE
Add link button in toolbar

### DIFF
--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { VISUAL_EDITOR_URL } from "../helpers/constants.js";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(VISUAL_EDITOR_URL);
+});
+
+test("link menu item disabled by default", async ({ page }) => {
+  await expect(page.getByText("🔗", { exact: true })).toBeDisabled();
+});
+
+test("link menu item enabled with selection", async ({ page }) => {
+  await page
+    .locator("#editor")
+    .getByText("Example link", { exact: true })
+    .selectText();
+  await expect(page.getByText("🔗", { exact: true })).toBeEnabled();
+});
+
+test("link menu item removes a selected link", async ({ page }) => {
+  await page
+    .locator("#editor")
+    .getByText("Example link", { exact: true })
+    .selectText();
+  await page.getByText("🔗", { exact: true }).click();
+  await expect(
+    page.locator("#editor").getByText("Example link", { exact: true }),
+  ).not.toHaveAttribute("href");
+});
+
+test("link menu item adds a link to selected text", async ({ page }) => {
+  await page
+    .locator("#editor")
+    .getByText("Example link", { exact: true })
+    .selectText();
+  await page.getByText("🔗", { exact: true }).click();
+  page.on("dialog", (dialog) => dialog.accept("example.com"));
+  await page.getByText("🔗", { exact: true }).click();
+  await expect(
+    page.locator("#editor").getByText("Example link", { exact: true }),
+  ).toHaveAttribute("href", "example.com");
+});

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <body>
     <div id="content" hidden>
       <p>Hello world, this is the ProseMirror editor.</p>
+      <p><a href="example.com">Example link</a></p>
       <h2>This is an H2 heading</h2>
       <h3>This is an H3 heading</h3>
       <ol>

--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -24,35 +24,15 @@ export const schema = {
 
 export const serializerSpec = {
   open(state, mark, parent, index) {
-    state.inAutolink = isPlainURL(mark, parent, index);
-    return state.inAutolink ? "<" : "[";
+    return "[";
   },
   close(state, mark, parent, index) {
-    const { inAutolink } = state;
-    state.inAutolink = undefined;
-    return inAutolink
-      ? ">"
-      : "](" +
-          mark.attrs.href.replace(/[()"]/g, "\\$&") +
-          (mark.attrs.title
-            ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"`
-            : "") +
-          ")";
+    return (
+      "](" +
+      mark.attrs.href.replace(/[()"]/g, "\\$&") +
+      (mark.attrs.title ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"` : "") +
+      ")"
+    );
   },
   mixable: true,
 };
-
-function isPlainURL(link, parent, index) {
-  if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false;
-  const content = parent.child(index);
-  if (
-    !content.isText ||
-    content.text !== link.attrs.href ||
-    content.marks[content.marks.length - 1] !== link
-  )
-    return false;
-  return (
-    index === parent.childCount - 1 ||
-    !link.isInSet(parent.child(index + 1).marks)
-  );
-}

--- a/lib/plugins/menu-plugin-view.js
+++ b/lib/plugins/menu-plugin-view.js
@@ -5,7 +5,7 @@ export default class MenuPluginView {
     this.dom.className = "menubar govuk-button-group";
     this.dom.role = "toolbar";
 
-    items.forEach(({ command, dom }, index) => {
+    items.forEach(({ command, dom, customHandler }, index) => {
       const button = this.dom.appendChild(dom);
       button.setAttribute("tabindex", index === 0 ? 0 : -1);
 
@@ -20,7 +20,11 @@ export default class MenuPluginView {
 
       button.addEventListener("click", (e) => {
         e.preventDefault();
-        command(editorView.state, editorView.dispatch, editorView);
+        if (customHandler) {
+          customHandler(editorView.state, editorView.dispatch, editorView);
+        } else {
+          command(editorView.state, editorView.dispatch, editorView);
+        }
         editorView.focus();
       });
     });

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -1,4 +1,4 @@
-import { chainCommands, setBlockType } from "prosemirror-commands";
+import { chainCommands, setBlockType, toggleMark } from "prosemirror-commands";
 import { wrapInList } from "prosemirror-schema-list";
 import { redo, undo } from "prosemirror-history";
 import { Plugin } from "prosemirror-state";
@@ -52,6 +52,24 @@ function stepsMenuItem(schema) {
   };
 }
 
+function linkMenuItem(schema) {
+  return {
+    command: (state) => !state.selection.empty,
+    dom: button("Link", "🔗"),
+    customHandler: (state, dispatch, editorView) => {
+      const selectionHasLink = state.selection.ranges.some((r) =>
+        state.doc.rangeHasMark(r.$from.pos, r.$to.pos, schema.marks.link),
+      );
+      let href = null;
+      if (!selectionHasLink) {
+        href = prompt("Enter absolute admin paths or full public URLs");
+        if (!href) return;
+      }
+      toggleMark(schema.marks.link, { href })(state, dispatch);
+    },
+  };
+}
+
 function undoMenuItem(schema) {
   return {
     command: undo,
@@ -72,6 +90,7 @@ function items(schema) {
     bulletListMenuItem(schema),
     orderedListMenuItem(schema),
     stepsMenuItem(schema),
+    linkMenuItem(schema),
     undoMenuItem(schema),
     redoMenuItem(schema),
   ];


### PR DESCRIPTION
## What
- Simplify the link mark.
- Add a link button to the toolbar.
- Enable the link button based on whether or not a selection has been made.
- When the button is pressed, either remove the link mark from the selection or prompt the user for a URL.

## Why
- By user the selection and browser prompt we don't need to implement a dialog in the visual editor
- This is good enough for the trial (but will likely have to be addressed in future).
- https://trello.com/c/zsI4Yzp1/2598-link-toolbar-components

## Recording
https://github.com/alphagov/govspeak-visual-editor/assets/9594455/f778e1aa-3bf2-48c8-81dc-f987e6eff10c
