### PR TITLE
Introduce "email link" component/toolbar button

### DIFF
--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -5,38 +5,64 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("link menu item disabled by default", async ({ page }) => {
-  await expect(page.getByTitle("Link", { exact: true })).toBeDisabled();
+test.describe("Link", () => {
+  test("link menu item disabled by default", async ({ page }) => {
+    await expect(page.getByTitle("Link", { exact: true })).toBeDisabled();
+  });
+
+  test("link menu item enabled with selection", async ({ page }) => {
+    await page
+      .locator("#editor")
+      .getByText("Example link", { exact: true })
+      .selectText();
+    await expect(page.getByTitle("Link", { exact: true })).toBeEnabled();
+  });
+
+  test("link menu item removes a selected link", async ({ page }) => {
+    await page
+      .locator("#editor")
+      .getByText("Example link", { exact: true })
+      .selectText();
+    await page.getByTitle("Link", { exact: true }).click();
+    await expect(
+      page.locator("#editor").getByText("Example link", { exact: true }),
+    ).not.toHaveAttribute("href");
+  });
+
+  test("link menu item adds a link to selected text", async ({ page }) => {
+    await page
+      .locator("#editor")
+      .getByText("Example link", { exact: true })
+      .selectText();
+    await page.getByTitle("Link", { exact: true }).click();
+    page.on("dialog", (dialog) => dialog.accept("example.com"));
+    await page.getByTitle("Link", { exact: true }).click();
+    await expect(
+      page.locator("#editor").getByText("Example link", { exact: true }),
+    ).toHaveAttribute("href", "example.com");
+  });
 });
 
-test("link menu item enabled with selection", async ({ page }) => {
-  await page
-    .locator("#editor")
-    .getByText("Example link", { exact: true })
-    .selectText();
-  await expect(page.getByTitle("Link", { exact: true })).toBeEnabled();
-});
+test.describe("Email link", () => {
+  test("email link menu item disabled by default", async ({ page }) => {
+    await expect(page.getByTitle("Link", { exact: true })).toBeDisabled();
+  });
 
-test("link menu item removes a selected link", async ({ page }) => {
-  await page
-    .locator("#editor")
-    .getByText("Example link", { exact: true })
-    .selectText();
-  await page.getByTitle("Link", { exact: true }).click();
-  await expect(
-    page.locator("#editor").getByText("Example link", { exact: true }),
-  ).not.toHaveAttribute("href");
-});
+  test("email link menu item enabled with selection", async ({ page }) => {
+    await page
+      .locator("#editor")
+      .getByText("Example link", { exact: true })
+      .selectText();
+    await expect(page.getByTitle("Link", { exact: true })).toBeEnabled();
+  });
 
-test("link menu item adds a link to selected text", async ({ page }) => {
-  await page
-    .locator("#editor")
-    .getByText("Example link", { exact: true })
-    .selectText();
-  await page.getByTitle("Link", { exact: true }).click();
-  page.on("dialog", (dialog) => dialog.accept("example.com"));
-  await page.getByTitle("Link", { exact: true }).click();
-  await expect(
-    page.locator("#editor").getByText("Example link", { exact: true }),
-  ).toHaveAttribute("href", "example.com");
+  test("email link menu item prompts the user for an email that it links to", async ({
+    page,
+  }) => {
+    page.on("dialog", (dialog) => dialog.accept("contact@example.com"));
+    await page.getByTitle("Email link", { exact: true }).click();
+    await expect(
+      page.locator("#editor").getByText("contact@example.com", { exact: true }),
+    ).toHaveAttribute("href", "mailto:contact@example.com");
+  });
 });

--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("link menu item disabled by default", async ({ page }) => {
-  await expect(page.getByText("🔗", { exact: true })).toBeDisabled();
+  await expect(page.getByTitle("Link", { exact: true })).toBeDisabled();
 });
 
 test("link menu item enabled with selection", async ({ page }) => {
@@ -14,7 +14,7 @@ test("link menu item enabled with selection", async ({ page }) => {
     .locator("#editor")
     .getByText("Example link", { exact: true })
     .selectText();
-  await expect(page.getByText("🔗", { exact: true })).toBeEnabled();
+  await expect(page.getByTitle("Link", { exact: true })).toBeEnabled();
 });
 
 test("link menu item removes a selected link", async ({ page }) => {
@@ -22,7 +22,7 @@ test("link menu item removes a selected link", async ({ page }) => {
     .locator("#editor")
     .getByText("Example link", { exact: true })
     .selectText();
-  await page.getByText("🔗", { exact: true }).click();
+  await page.getByTitle("Link", { exact: true }).click();
   await expect(
     page.locator("#editor").getByText("Example link", { exact: true }),
   ).not.toHaveAttribute("href");
@@ -33,9 +33,9 @@ test("link menu item adds a link to selected text", async ({ page }) => {
     .locator("#editor")
     .getByText("Example link", { exact: true })
     .selectText();
-  await page.getByText("🔗", { exact: true }).click();
+  await page.getByTitle("Link", { exact: true }).click();
   page.on("dialog", (dialog) => dialog.accept("example.com"));
-  await page.getByText("🔗", { exact: true }).click();
+  await page.getByTitle("Link", { exact: true }).click();
   await expect(
     page.locator("#editor").getByText("Example link", { exact: true }),
   ).toHaveAttribute("href", "example.com");

--- a/lib/__snapshots__/markdown.test.js.snap
+++ b/lib/__snapshots__/markdown.test.js.snap
@@ -27,3 +27,11 @@ example callout$E
 
 %warning callout%"
 `;
+
+exports[`Links and email links 1`] = `
+"[link](example.com)
+
+<contact@example.com>
+
+[link](mailto:contact@example.com)"
+`;

--- a/lib/markdown.test.js
+++ b/lib/markdown.test.js
@@ -10,6 +10,7 @@ const {
   example_callout,
   information_callout,
   warning_callout,
+  link,
 } = builders(schema);
 
 test("Custom nodes", () => {
@@ -20,6 +21,16 @@ test("Custom nodes", () => {
     example_callout("example callout"),
     information_callout("information callout"),
     warning_callout("warning callout"),
+  );
+
+  expect(markdownSerializer.serialize(state)).toMatchSnapshot();
+});
+
+test("Links and email links", () => {
+  const state = doc(
+    p(link({ href: "example.com" }, "link")),
+    p(link({ href: "mailto:contact@example.com" }, "contact@example.com")),
+    p(link({ href: "mailto:contact@example.com" }, "link")),
   );
 
   expect(markdownSerializer.serialize(state)).toMatchSnapshot();

--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -24,15 +24,28 @@ export const schema = {
 
 export const serializerSpec = {
   open(state, mark, parent, index) {
-    return "[";
+    state.inEmail = isEmail(mark, parent, index);
+    return state.inEmail ? "<" : "[";
   },
   close(state, mark, parent, index) {
-    return (
-      "](" +
-      mark.attrs.href.replace(/[()"]/g, "\\$&") +
-      (mark.attrs.title ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"` : "") +
-      ")"
-    );
+    const { inEmail } = state;
+    state.inEmail = undefined;
+    return inEmail
+      ? ">"
+      : "](" +
+          mark.attrs.href.replace(/[()"]/g, "\\$&") +
+          (mark.attrs.title
+            ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"`
+            : "") +
+          ")";
   },
   mixable: true,
 };
+
+function isEmail(mark, parent, index) {
+  if (!mark.attrs.href.startsWith("mailto:")) return false;
+  const content = parent.child(index).text;
+  return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
+    content,
+  );
+}

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -8,6 +8,7 @@ import bulletListIconUrl from "../icons/bullet-list.svg";
 import orderedListIconUrl from "../icons/ordered-list.svg";
 import stepsIconUrl from "../icons/steps.svg";
 import linkIconUrl from "../icons/link.svg";
+import emailLinkIconUrl from "../icons/email-link.svg";
 import undoIconUrl from "../icons/undo.svg";
 import redoIconUrl from "../icons/redo.svg";
 
@@ -71,6 +72,24 @@ function linkMenuItem(schema) {
   };
 }
 
+function emailLinkMenuItem(schema) {
+  return {
+    command: (...[state, , view]) =>
+      state.selection.empty && toggleMark(schema.marks.link)(state, null, view),
+    dom: button("Email link", emailLinkIconUrl),
+    customHandler: (state, dispatch, editorView) => {
+      const email = prompt("Enter the email address");
+      if (!email) return;
+      dispatch(
+        state.tr
+          .addStoredMark(schema.marks.link.create({ href: `mailto:${email}` }))
+          .insertText(email),
+      );
+      editorView.focus();
+    },
+  };
+}
+
 function undoMenuItem(schema) {
   return {
     command: undo,
@@ -92,6 +111,7 @@ function items(schema) {
     orderedListMenuItem(schema),
     stepsMenuItem(schema),
     linkMenuItem(schema),
+    emailLinkMenuItem(schema),
     undoMenuItem(schema),
     redoMenuItem(schema),
   ];


### PR DESCRIPTION
- Add an email link button, enabled when no text is selected and a link can be inserted
- Prompt the user for an email when the button is clicked and insert it as a link with a mailto:
- Update the link markdown to write valid email addresses with links as is to govspeak
- Add tests for this behaviour

https://trello.com/c/nRkluyhL/2526-introduce-email-link-component-toolbar-button