### PR TITLE
Prompt users for link contents when text is not selected

### DIFF
--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -6,15 +6,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe("Link", () => {
-  test("link menu item disabled by default", async ({ page }) => {
-    await expect(page.getByTitle("Link", { exact: true })).toBeDisabled();
-  });
-
-  test("link menu item enabled with selection", async ({ page }) => {
-    await page
-      .locator("#editor")
-      .getByText("Example link", { exact: true })
-      .selectText();
+  test("link menu item enabled by default", async ({ page }) => {
     await expect(page.getByTitle("Link", { exact: true })).toBeEnabled();
   });
 
@@ -41,19 +33,29 @@ test.describe("Link", () => {
       page.locator("#editor").getByText("Example link", { exact: true }),
     ).toHaveAttribute("href", "example.com");
   });
+
+  test("link menu item inserts a link when text is not selected", async ({
+    page,
+  }) => {
+    page.on("dialog", (dialog) => dialog.accept("example.com"));
+    await page.getByTitle("Link", { exact: true }).click();
+    await expect(
+      page.locator("#editor").getByText("example.com", { exact: true }),
+    ).toHaveAttribute("href", "example.com");
+  });
 });
 
 test.describe("Email link", () => {
-  test("email link menu item disabled by default", async ({ page }) => {
-    await expect(page.getByTitle("Link", { exact: true })).toBeDisabled();
+  test("email link menu item enabled by default", async ({ page }) => {
+    await expect(page.getByTitle("Email link", { exact: true })).toBeEnabled();
   });
 
-  test("email link menu item enabled with selection", async ({ page }) => {
+  test("email link menu item disabled with selection", async ({ page }) => {
     await page
       .locator("#editor")
       .getByText("Example link", { exact: true })
       .selectText();
-    await expect(page.getByTitle("Link", { exact: true })).toBeEnabled();
+    await expect(page.getByTitle("Email link", { exact: true })).toBeDisabled();
   });
 
   test("email link menu item prompts the user for an email that it links to", async ({

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -56,18 +56,35 @@ function stepsMenuItem(schema) {
 
 function linkMenuItem(schema) {
   return {
-    command: (state) => !state.selection.empty,
+    command: toggleMark(schema.marks.link),
     dom: button("Link", linkIconUrl),
     customHandler: (state, dispatch, editorView) => {
-      const selectionHasLink = state.selection.ranges.some((r) =>
-        state.doc.rangeHasMark(r.$from.pos, r.$to.pos, schema.marks.link),
-      );
-      let href = null;
-      if (!selectionHasLink) {
-        href = prompt("Enter absolute admin paths or full public URLs");
-        if (!href) return;
+      const selectionHasLink =
+        !state.selection.empty &&
+        state.selection.ranges.some((r) =>
+          state.doc.rangeHasMark(r.$from.pos, r.$to.pos, schema.marks.link),
+        );
+      if (selectionHasLink) {
+        toggleMark(schema.marks.link)(state, dispatch);
+        editorView.focus();
+        return;
       }
-      toggleMark(schema.marks.link, { href })(state, dispatch);
+
+      let href = null;
+      href = prompt("Enter absolute admin paths or full public URLs");
+      if (!href) return;
+
+      if (!state.selection.empty) {
+        toggleMark(schema.marks.link, { href })(state, dispatch);
+      } else {
+        const text = prompt("Enter the link text");
+        dispatch(
+          state.tr
+            .addStoredMark(schema.marks.link.create({ href }))
+            .insertText(text),
+        );
+      }
+      editorView.focus();
     },
   };
 }


### PR DESCRIPTION
## What
- Prompt users for link contents when text is not selected

## Why
- Previously it was only possible to select text and mark it as a link. This behaviour was confusing so instead we prompt users a second time for the text content when no text is selected.

https://trello.com/c/cEeqVN2d/2620-toolbar-interaction-improvements
