### PR TITLE
Introduce heading and text block select menus

### DIFF
--- a/e2e/menu_items_block/addresses.spec.js
+++ b/e2e/menu_items_block/addresses.spec.js
@@ -5,84 +5,99 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders address menu items with expected disabled states",
-  async ({ page }) => {
-    await page.getByText("$A", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [
-      "“”",
-      "$A",
-      "$CTA",
-      "$C",
-      "$E",
-      "^",
-      "%",
-      "1.",
-      "-",
-    ];
-    const disabledMenuButtons = ["p", "H2", "H3"];
+test("renders address menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Address");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+  const enabledMenuButtons = [
+    "Link",
+    "Email link",
+    "Bullet list",
+    "Ordered list",
+    "Steps",
+  ];
+  const disabledMenuButtons = ["Heading 2"];
 
-test.fixme(
-  "loads addresses from the index file in the editor",
-  async ({ page }) => {
-    await expect(
-      page.locator("#editor .address").getByText("HM Revenue and Customs"),
-    ).toBeVisible();
-  },
-);
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-test.fixme(
-  "should render address in the editor on multiple lines clearing on double enter when clicking on '$A' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  const enabledSelectOptions = [
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Contact",
+    "Address",
+    "Blockquote",
+  ];
+  const disabledSelectOptions = ["H3", "H4", "H5", "H6"];
 
-    await page.getByText("New line").click();
-    await page.getByText("$A", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type("Address line 1\nAddress line 2\n\nNot address\n");
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-    await expect(
-      page.locator("#editor .address").getByText("Address line 1"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .address").getByText("Address line 2"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .address").getByText("Not address"),
-    ).not.toBeVisible();
-  },
-);
+test("loads addresses from the index file in the editor", async ({ page }) => {
+  await expect(
+    page.locator("#editor .address").getByText("HM Revenue and Customs"),
+  ).toBeVisible();
+});
 
-test.fixme(
-  "should toggle address for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
+test("should render address in the editor on multiple lines clearing on double enter when clicking on 'Address' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
 
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("$A", { exact: true }).click();
-    await expect(
-      page.locator("#editor .address").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Address");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type("Address line 1\nAddress line 2\n\nNot address\n");
 
-test.fixme("should allow embedding of other content", async ({ page }) => {
-  await page.getByText("$A", { exact: true }).click();
+  await expect(
+    page.locator("#editor .address").getByText("Address line 1"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .address").getByText("Address line 2"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .address").getByText("Not address"),
+  ).not.toBeVisible();
+});
+
+test("should toggle address for existing paragraph line", async ({ page }) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Address");
+  await expect(
+    page.locator("#editor .address").getByText("Testing paragraph"),
+  ).toBeVisible();
+});
+
+test("should allow embedding of other content", async ({ page }) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Address");
   await page.locator("#editor .ProseMirror.govspeak").focus();
   await page.keyboard.type("Testing address\n\n");
 
   await page.locator("#editor .address").getByText("Testing address").click();
-  await page.getByText("$A", { exact: true }).click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Address");
   await expect(
     page.locator("#editor .address .address").getByText("Testing address"),
   ).toBeVisible();

--- a/e2e/menu_items_block/blockquote.spec.js
+++ b/e2e/menu_items_block/blockquote.spec.js
@@ -5,69 +5,85 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders blockquote menu items with expected disabled states",
-  async ({ page }) => {
-    await page.getByText("“”", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [];
-    const disabledMenuButtons = [
-      "H2",
-      "H3",
-      "p",
-      "“”",
-      "$A",
-      "$CTA",
-      "$C",
-      "$E",
-      "^",
-      "%",
-      "1.",
-      "-",
-    ];
+test("renders blockquote menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Blockquote");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+  const enabledMenuButtons = ["Link", "Email link"];
+  const disabledMenuButtons = [
+    "Heading 2",
+    "Bullet list",
+    "Ordered list",
+    "Steps",
+  ];
 
-test.fixme(
-  "should render blockquote in the editor on multiple lines clearing on double enter when clicking on '$A' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-    await page.getByText("New line").click();
-    await page.getByText("“”", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type(
-      "Blockquote line 1\nBlockquote line 2\n\nNot blockquote\n",
-    );
+  const enabledSelectOptions = [];
+  const disabledSelectOptions = [
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Contact",
+    "Address",
+    "Blockquote",
+  ];
 
-    await expect(
-      page.locator("#editor blockquote").getByText("Blockquote line 1"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor blockquote").getByText("Blockquote line 2"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor blockquote").getByText("Not blockquote"),
-    ).not.toBeVisible();
-  },
-);
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-test.fixme(
-  "should toggle blockquote for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
+test("should render blockquote in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
 
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("“”", { exact: true }).click();
-    await expect(
-      page.locator("#editor blockquote").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Blockquote");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type(
+    "Blockquote line 1\nBlockquote line 2\n\nNot blockquote\n",
+  );
+
+  await expect(
+    page.locator("#editor blockquote").getByText("Blockquote line 1"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor blockquote").getByText("Blockquote line 2"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor blockquote").getByText("Not blockquote"),
+  ).not.toBeVisible();
+});
+
+test("should toggle blockquote for existing paragraph line", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Blockquote");
+  await expect(
+    page.locator("#editor blockquote").getByText("Testing paragraph"),
+  ).toBeVisible();
+});

--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -5,79 +5,96 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders call to action menu items with expected disabled state",
-  async ({ page }) => {
-    await page.getByText("$CTA", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [
-      "“”",
-      "$A",
-      "$CTA",
-      "$C",
-      "$E",
-      "^",
-      "%",
-      "1.",
-      "-",
-    ];
-    const disabledMenuButtons = ["p", "H2", "H3"];
+test("renders blockquote menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Call to action");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+  const enabledMenuButtons = [
+    "Bullet list",
+    "Ordered list",
+    "Steps",
+    "Link",
+    "Email link",
+  ];
+  const disabledMenuButtons = ["Heading 2"];
 
-test.fixme(
-  "loads call to action from the index file in the editor",
-  async ({ page }) => {
-    await expect(
-      page.locator("#editor .call-to-action").getByText("Call to action"),
-    ).toBeVisible();
-  },
-);
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-test.fixme(
-  "should render call to action in the editor on multiple lines clearing on double enter when clicking on '$A' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  const enabledSelectOptions = [
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Contact",
+    "Address",
+    "Blockquote",
+  ];
+  const disabledSelectOptions = ["H3", "H4", "H5", "H6"];
 
-    await page.getByText("New line").click();
-    await page.getByText("$CTA", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type("Action 1\nAction 2\n\nNot action\n");
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-    await expect(
-      page.locator("#editor .call-to-action").getByText("Action 1"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .call-to-action").getByText("Action 2"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .call-to-action").getByText("Not action"),
-    ).not.toBeVisible();
-  },
-);
+test("loads call to action from the index file in the editor", async ({
+  page,
+}) => {
+  await expect(
+    page.locator("#editor .call-to-action").getByText("Call to action"),
+  ).toBeVisible();
+});
 
-test.fixme(
-  "should toggle call to action for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
+test("should render call to action in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
 
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("$CTA", { exact: true }).click();
-    await expect(
-      page.locator("#editor .call-to-action").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Call to action");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type("Action 1\nAction 2\n\nNot action\n");
 
-test.fixme("should allow embedding of other content", async ({ page }) => {
-  await page.getByText("$CTA", { exact: true }).click();
+  await expect(
+    page.locator("#editor .call-to-action").getByText("Action 1"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .call-to-action").getByText("Action 2"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .call-to-action").getByText("Not action"),
+  ).not.toBeVisible();
+});
+
+test("should toggle call to action for existing paragraph line", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Call to action");
+  await expect(
+    page.locator("#editor .call-to-action").getByText("Testing paragraph"),
+  ).toBeVisible();
+});
+
+test("should allow embedding of other content", async ({ page }) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Call to action");
   await page.locator("#editor .ProseMirror.govspeak").focus();
   await page.keyboard.type("Testing call to action\n\n");
 
@@ -85,7 +102,9 @@ test.fixme("should allow embedding of other content", async ({ page }) => {
     .locator("#editor .call-to-action")
     .getByText("Testing call to action")
     .click();
-  await page.getByText("$CTA", { exact: true }).click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Call to action");
   await expect(
     page
       .locator("#editor .call-to-action .call-to-action")

--- a/e2e/menu_items_block/contacts.spec.js
+++ b/e2e/menu_items_block/contacts.spec.js
@@ -5,75 +5,86 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders contacts menu items with expected disabled states",
-  async ({ page }) => {
-    await page.getByText("$C", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [];
-    const disabledMenuButtons = [
-      "H2",
-      "p",
-      "H3",
-      "“”",
-      "1.",
-      "-",
-      "$A",
-      "$CTA",
-      "$C",
-      "$E",
-      "^",
-      "%",
-    ];
+test("renders contact menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Contact");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+  const enabledMenuButtons = ["Link", "Email link"];
+  const disabledMenuButtons = [
+    "Heading 2",
+    "Bullet list",
+    "Ordered list",
+    "Steps",
+  ];
 
-test.fixme(
-  "loads contacts from the index file in the editor",
-  async ({ page }) => {
-    await expect(
-      page.locator("#editor .contact").getByText("Financial Conduct Authority"),
-    ).toBeVisible();
-  },
-);
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-test.fixme(
-  "should render contact in the editor on multiple lines clearing on double enter when clicking on '$A' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  const enabledSelectOptions = [];
+  const disabledSelectOptions = [
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Contact",
+    "Address",
+    "Blockquote",
+  ];
 
-    await page.getByText("New line").click();
-    await page.getByText("$C", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type("Contact line 1\nContact line 2\n\nNot contact\n");
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-    await expect(
-      page.locator("#editor .contact").getByText("Contact line 1"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .contact").getByText("Contact line 2"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .contact").getByText("Not contact"),
-    ).not.toBeVisible();
-  },
-);
+test("loads contacts from the index file in the editor", async ({ page }) => {
+  await expect(
+    page.locator("#editor .contact").getByText("Financial Conduct Authority"),
+  ).toBeVisible();
+});
 
-test.fixme(
-  "should toggle contact for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("$C", { exact: true }).click();
-    await expect(
-      page.locator("#editor .contact").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
+test("should render contact in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
+
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Contact");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type("Contact line 1\nContact line 2\n\nNot contact\n");
+
+  await expect(
+    page.locator("#editor .contact").getByText("Contact line 1"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .contact").getByText("Contact line 2"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .contact").getByText("Not contact"),
+  ).not.toBeVisible();
+});
+
+test("should toggle contact for existing paragraph line", async ({ page }) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Contact");
+  await expect(
+    page.locator("#editor .contact").getByText("Testing paragraph"),
+  ).toBeVisible();
+});

--- a/e2e/menu_items_block/example_callouts.spec.js
+++ b/e2e/menu_items_block/example_callouts.spec.js
@@ -5,62 +5,76 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders example callout menu items with expected disabled state",
-  async ({ page }) => {
-    await page.getByText("$E", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [
-      "“”",
-      "$A",
-      "$CTA",
-      "$C",
-      "$E",
-      "^",
-      "%",
-      "1.",
-      "-",
-    ];
-    const disabledMenuButtons = ["p", "H2", "H3"];
+test("renders example callout menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Example callout");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+  const enabledMenuButtons = [
+    "Bullet list",
+    "Ordered list",
+    "Steps",
+    "Link",
+    "Email link",
+  ];
+  const disabledMenuButtons = ["Heading 2"];
 
-test.fixme(
-  "loads example callout from the index file in the editor",
-  async ({ page }) => {
-    await expect(
-      page.locator("#editor .example").getByText("This is an example callout"),
-    ).toBeVisible();
-  },
-);
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-test.fixme(
-  "should render example callout in the editor on multiple lines clearing on double enter when clicking on '$A' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  const enabledSelectOptions = [
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Contact",
+    "Address",
+    "Blockquote",
+  ];
+  const disabledSelectOptions = ["H3", "H4", "H5", "H6"];
 
-    await page.getByText("New line").click();
-    await page.getByText("$E", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type("Example 1\nExample 2\n\nNot example\n");
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-    await expect(
-      page.locator("#editor .example").getByText("Example 1"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .example").getByText("Example 2"),
-    ).toBeVisible();
-    await expect(
-      page.locator("#editor .example").getByText("Not example"),
-    ).not.toBeVisible();
-  },
-);
+test("loads example callout from the index file in the editor", async ({
+  page,
+}) => {
+  await expect(
+    page.locator("#editor .example").getByText("This is an example callout"),
+  ).toBeVisible();
+});
+
+test("should render example callout in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
+
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Example callout");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type("Example 1\nExample 2\n\nNot example\n");
+
+  await expect(
+    page.locator("#editor .example").getByText("Example 1"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .example").getByText("Example 2"),
+  ).toBeVisible();
+  await expect(
+    page.locator("#editor .example").getByText("Not example"),
+  ).not.toBeVisible();
+});
 
 test.fixme(
   "should toggle example callout for existing paragraph line",
@@ -69,15 +83,19 @@ test.fixme(
     await page.keyboard.type("Testing paragraph\n");
 
     await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("$E", { exact: true }).click();
+    await page
+      .locator('select:has-text("Add text block")')
+      .selectOption("Example callout");
     await expect(
       page.locator("#editor .example").getByText("Testing paragraph"),
     ).toBeVisible();
   },
 );
 
-test.fixme("should allow embedding of other content", async ({ page }) => {
-  await page.getByText("$E", { exact: true }).click();
+test("should allow embedding of other content", async ({ page }) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Example callout");
   await page.locator("#editor .ProseMirror.govspeak").focus();
   await page.keyboard.type("Testing example callout\n\n");
 
@@ -85,7 +103,9 @@ test.fixme("should allow embedding of other content", async ({ page }) => {
     .locator("#editor .example")
     .getByText("Testing example callout")
     .click();
-  await page.getByText("$E", { exact: true }).click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Example callout");
   await expect(
     page
       .locator("#editor .example .example")

--- a/e2e/menu_items_inline/information_callouts.spec.js
+++ b/e2e/menu_items_inline/information_callouts.spec.js
@@ -5,84 +5,109 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders information callout menu items with expected disabled states",
-  async ({ page }) => {
-    await page.getByText("^", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$E", "%"];
-    const disabledMenuButtons = ["“”", "^", "1.", "-", "$C"];
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+test("renders information callout menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Information callout");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-test.fixme(
-  "loads information callouts from the index file in the editor",
-  async ({ page }) => {
-    await expect(
-      page
-        .locator("#editor .info-notice")
-        .getByText("This is an information callout"),
-    ).toBeVisible();
-  },
-);
+  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
+  const disabledMenuButtons = ["Bullet list", "Ordered list", "Steps"];
 
-test.fixme(
-  "should render information callouts in the editor and clear style after new line when clicking on 'H2' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-    await page.getByText("New line").click();
-    await page.getByText("^", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type(
-      "Testing information callout!\nTesting not information callout!\n",
-    );
-    await expect(
-      page
-        .locator("#editor .info-notice")
-        .getByText("Testing information callout!"),
-    ).toBeVisible();
-    await expect(
-      page
-        .locator("#editor .info-notice")
-        .getByText("Testing not information callout!"),
-    ).not.toBeVisible();
-  },
-);
+  const enabledSelectOptions = [
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Address",
+  ];
+  const disabledSelectOptions = ["Contact", "Blockquote"];
 
-test.fixme(
-  "should toggle information callout for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("^", { exact: true }).click();
-    await expect(
-      page.locator("#editor .info-notice").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
-
-test.fixme(
-  "should toggle information callout off for existing callout",
-  async ({ page }) => {
-    await page.getByText("^", { exact: true }).click();
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing information callout\n");
-
-    await page
+test("loads information callouts from the index file in the editor", async ({
+  page,
+}) => {
+  await expect(
+    page
       .locator("#editor .info-notice")
-      .getByText("Testing information callout")
-      .click();
-    await page.getByText("p", { exact: true }).click();
-    await expect(
-      page.locator("#editor p").getByText("Testing information callout"),
-    ).toBeVisible();
-  },
-);
+      .getByText("This is an information callout"),
+  ).toBeVisible();
+});
+
+test("should render information callouts in the editor and clear style after new line when clicking on 'Information callout' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
+
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Information callout");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type(
+    "Testing information callout!\nTesting not information callout!\n",
+  );
+  await expect(
+    page
+      .locator("#editor .info-notice")
+      .getByText("Testing information callout!"),
+  ).toBeVisible();
+  await expect(
+    page
+      .locator("#editor .info-notice")
+      .getByText("Testing not information callout!"),
+  ).not.toBeVisible();
+});
+
+test("should toggle information callout for existing paragraph line", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Information callout");
+  await expect(
+    page.locator("#editor .info-notice").getByText("Testing paragraph"),
+  ).toBeVisible();
+});
+
+test("should toggle information callout off for existing callout", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Information callout");
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing information callout\n");
+
+  await page
+    .locator("#editor .info-notice")
+    .getByText("Testing information callout")
+    .click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Information callout");
+  await expect(
+    page.locator("#editor p").getByText("Testing information callout"),
+  ).toBeVisible();
+});

--- a/e2e/menu_items_inline/warning_callouts.spec.js
+++ b/e2e/menu_items_inline/warning_callouts.spec.js
@@ -5,85 +5,105 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.fixme(
-  "renders warning callout menu items with expected disabled states",
-  async ({ page }) => {
-    await page.getByText("%", { exact: true }).click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = ["p", "H2", "H3", "$A", "$CTA", "$E", "^"];
-    const disabledMenuButtons = ["“”", "%", "1.", "-", "$C"];
+test("renders warning callout menu items with expected disabled states", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Warning callout");
+  await expect(page.locator(".menubar")).toBeVisible();
 
-    for (const button of enabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
-  },
-);
+  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
+  const disabledMenuButtons = ["Bullet list", "Ordered list", "Steps"];
 
-test.fixme(
-  "loads warning callouts from the index file in the editor",
-  async ({ page }) => {
-    await expect(
-      page
-        .locator("#editor .help-notice")
-        .getByText("This is a warning callout"),
-    ).toBeVisible();
-  },
-);
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-test.fixme(
-  "should render warning callouts in the editor and clear style after new line when clicking on 'H2' and typing",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
+  const enabledSelectOptions = [
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "Call to action",
+    "Information callout",
+    "Warning callout",
+    "Example callout",
+    "Address",
+  ];
+  const disabledSelectOptions = ["Contact", "Blockquote"];
 
-    await page.getByText("New line").click();
-    await page.getByText("%", { exact: true }).click();
-    await page.getByText("New line").selectText();
-    await page.keyboard.type(
-      "Testing warning callout!\nTesting not warning callout!\n",
-    );
-    await expect(
-      page
-        .locator("#editor .help-notice")
-        .getByText("Testing warning callout!"),
-    ).toBeVisible();
-    await expect(
-      page
-        .locator("#editor .help-notice")
-        .getByText("Testing not warning callout!"),
-    ).not.toBeVisible();
-  },
-);
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
 
-test.fixme(
-  "should toggle warning callout for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
+test("loads warning callouts from the index file in the editor", async ({
+  page,
+}) => {
+  await expect(
+    page.locator("#editor .help-notice").getByText("This is a warning callout"),
+  ).toBeVisible();
+});
 
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("%", { exact: true }).click();
-    await expect(
-      page.locator("#editor .help-notice").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
+test("should render warning callouts in the editor and clear style after new line when selecting 'Warning callout' and typing", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("New line\n");
 
-test.fixme(
-  "should toggle warning callout off for existing callout",
-  async ({ page }) => {
-    await page.getByText("%", { exact: true }).click();
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing warning callout\n");
-
-    await page
+  await page.getByText("New line").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Warning callout");
+  await page.getByText("New line").selectText();
+  await page.keyboard.type(
+    "Testing warning callout!\nTesting not warning callout!\n",
+  );
+  await expect(
+    page.locator("#editor .help-notice").getByText("Testing warning callout!"),
+  ).toBeVisible();
+  await expect(
+    page
       .locator("#editor .help-notice")
-      .getByText("Testing warning callout")
-      .click();
-    await page.getByText("p", { exact: true }).click();
-    await expect(
-      page.locator("#editor p").getByText("Testing warning callout"),
-    ).toBeVisible();
-  },
-);
+      .getByText("Testing not warning callout!"),
+  ).not.toBeVisible();
+});
+
+test("should toggle warning callout for existing paragraph line", async ({
+  page,
+}) => {
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing paragraph\n");
+
+  await page.locator("#editor p").getByText("Testing paragraph").click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Warning callout");
+  await expect(
+    page.locator("#editor .help-notice").getByText("Testing paragraph"),
+  ).toBeVisible();
+});
+
+test("should toggle warning callout off for existing callout", async ({
+  page,
+}) => {
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Warning callout");
+  await page.locator("#editor .ProseMirror.govspeak").focus();
+  await page.keyboard.type("Testing warning callout\n");
+
+  await page
+    .locator("#editor .help-notice")
+    .getByText("Testing warning callout")
+    .click();
+  await page
+    .locator('select:has-text("Add text block")')
+    .selectOption("Warning callout");
+  await expect(
+    page.locator("#editor p").getByText("Testing warning callout"),
+  ).toBeVisible();
+});

--- a/lib/plugins/menu-plugin-view.js
+++ b/lib/plugins/menu-plugin-view.js
@@ -63,9 +63,10 @@ export default class MenuPluginView {
   update(view) {
     const focusableButton = this.dom.querySelector('[tabindex="0"]');
 
-    this.items.forEach(({ command, dom }) => {
+    this.items.forEach(({ command, dom, update }) => {
       const active = command(view.state, null, view);
       dom.disabled = !active;
+      if (update) update(view);
     });
 
     if (!focusableButton || !focusableButton.disabled) return;

--- a/lib/plugins/menu-plugin-view.js
+++ b/lib/plugins/menu-plugin-view.js
@@ -24,8 +24,8 @@ export default class MenuPluginView {
           customHandler(editorView.state, editorView.dispatch, editorView);
         } else {
           command(editorView.state, editorView.dispatch, editorView);
+          editorView.focus();
         }
-        editorView.focus();
       });
     });
 

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -23,6 +23,31 @@ function button(title, iconUrl) {
   return button;
 }
 
+function select(options, editorView) {
+  const select = document.createElement("select");
+  select.className = "govuk-select";
+  options.forEach((o, index) => {
+    o.dom = document.createElement("option");
+    o.dom.text = o.text;
+    o.dom.value = index;
+    select.appendChild(o.dom);
+  });
+  select.addEventListener("change", () => {
+    options[Number(select.value)].command(
+      editorView.state,
+      editorView.dispatch,
+      editorView,
+    );
+    editorView.focus();
+    select.selectedIndex = 0;
+  });
+  return {
+    command: chainCommands(...options.map((o) => o.command)),
+    dom: select,
+    customHandler: () => {},
+  };
+}
+
 function headingMenuItem(schema) {
   return {
     command: chainCommands(
@@ -31,6 +56,43 @@ function headingMenuItem(schema) {
     ),
     dom: button("Heading 2", headingIconUrl),
   };
+}
+
+function headingMenuSelectOptions(schema) {
+  return [
+    {
+      text: "H",
+      command: () => {},
+    },
+    {
+      text: "H3",
+      command: chainCommands(
+        setBlockType(schema.nodes.heading, { level: 3 }),
+        setBlockType(schema.nodes.paragraph),
+      ),
+    },
+    {
+      text: "H4",
+      command: chainCommands(
+        setBlockType(schema.nodes.heading, { level: 4 }),
+        setBlockType(schema.nodes.paragraph),
+      ),
+    },
+    {
+      text: "H5",
+      command: chainCommands(
+        setBlockType(schema.nodes.heading, { level: 5 }),
+        setBlockType(schema.nodes.paragraph),
+      ),
+    },
+    {
+      text: "H6",
+      command: chainCommands(
+        setBlockType(schema.nodes.heading, { level: 6 }),
+        setBlockType(schema.nodes.paragraph),
+      ),
+    },
+  ];
 }
 
 function bulletListMenuItem(schema) {
@@ -121,9 +183,10 @@ function redoMenuItem(schema) {
   };
 }
 
-function items(schema) {
+function items(schema, editorView) {
   return [
     headingMenuItem(schema),
+    select(headingMenuSelectOptions(schema), editorView),
     bulletListMenuItem(schema),
     orderedListMenuItem(schema),
     stepsMenuItem(schema),
@@ -136,6 +199,7 @@ function items(schema) {
 
 export default function menu(schema) {
   return new Plugin({
-    view: (editorView) => new MenuPluginView(items(schema), editorView),
+    view: (editorView) =>
+      new MenuPluginView(items(schema, editorView), editorView),
   });
 }

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -1,4 +1,9 @@
-import { chainCommands, setBlockType, toggleMark } from "prosemirror-commands";
+import {
+  chainCommands,
+  setBlockType,
+  toggleMark,
+  wrapIn,
+} from "prosemirror-commands";
 import { wrapInList } from "prosemirror-schema-list";
 import { redo, undo } from "prosemirror-history";
 import { Plugin } from "prosemirror-state";
@@ -45,6 +50,11 @@ function select(options, editorView) {
     command: chainCommands(...options.map((o) => o.command)),
     dom: select,
     customHandler: () => {},
+    update: (view) => {
+      options.forEach((o) => {
+        o.dom.disabled = !o.command(view.state, null, view);
+      });
+    },
   };
 }
 
@@ -169,6 +179,49 @@ function emailLinkMenuItem(schema) {
   };
 }
 
+function textBlockMenuSelectOptions(schema) {
+  return [
+    {
+      text: "Add text block",
+      command: () => {},
+    },
+    {
+      text: "Call to action",
+      command: wrapIn(schema.nodes.call_to_action),
+    },
+    {
+      text: "Information callout",
+      command: chainCommands(
+        setBlockType(schema.nodes.information_callout),
+        setBlockType(schema.nodes.paragraph),
+      ),
+    },
+    {
+      text: "Warning callout",
+      command: chainCommands(
+        setBlockType(schema.nodes.warning_callout),
+        setBlockType(schema.nodes.paragraph),
+      ),
+    },
+    {
+      text: "Example callout",
+      command: wrapIn(schema.nodes.example_callout),
+    },
+    {
+      text: "Contact",
+      command: wrapIn(schema.nodes.contact),
+    },
+    {
+      text: "Address",
+      command: wrapIn(schema.nodes.address),
+    },
+    {
+      text: "Blockquote",
+      command: wrapIn(schema.nodes.blockquote),
+    },
+  ];
+}
+
 function undoMenuItem(schema) {
   return {
     command: undo,
@@ -192,6 +245,7 @@ function items(schema, editorView) {
     stepsMenuItem(schema),
     linkMenuItem(schema),
     emailLinkMenuItem(schema),
+    select(textBlockMenuSelectOptions(schema), editorView),
     undoMenuItem(schema),
     redoMenuItem(schema),
   ];

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -43,3 +43,8 @@
 .menubar .govuk-button--secondary:not(:hover) {
   box-shadow: none;
 }
+
+.menubar .govuk-select {
+  min-width: 0;
+  margin-right: 5px;
+}


### PR DESCRIPTION
- Introduce a select helper and use it to create heading and text block select menus menu.
- Use the custom handler to prevent the default behaviour and listen to the 'change' event on the select instead.
- Introduce an update callback for menu items and use it to programatically enable and disable the options in the select.
- Reinstate testing now that we have all of the block types in the menu again.

https://trello.com/c/w4HwXw42/2606-h3-h6-toolbar-dropdown
https://trello.com/c/9JnXLroA/2600-text-block-menu-component

## Screenshot
<img width="715" alt="Screenshot 2024-05-16 at 17 25 48" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/3edbf42b-e417-4acc-b4e3-53358108cd4b">
