### PR TITLE
Introduce insert menu and adjust select widths

### DIFF
--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -28,9 +28,9 @@ function button(title, iconUrl) {
   return button;
 }
 
-function select(options, editorView) {
+function select(options, editorView, className) {
   const select = document.createElement("select");
-  select.className = "govuk-select";
+  select.className = `govuk-select ${className}`;
   options.forEach((o, index) => {
     o.dom = document.createElement("option");
     o.dom.text = o.text;
@@ -222,6 +222,23 @@ function textBlockMenuSelectOptions(schema) {
   ];
 }
 
+function insertMenuSelectOptions(schema) {
+  return [
+    {
+      text: "Insert",
+      command: wrapIn(schema.nodes.call_to_action), // Temporary command to get appropriate enabled/disabled behaviour
+    },
+    {
+      text: "Image",
+      command: () => {},
+    },
+    {
+      text: "Attachemnt",
+      command: () => {},
+    },
+  ];
+}
+
 function undoMenuItem(schema) {
   return {
     command: undo,
@@ -239,13 +256,14 @@ function redoMenuItem(schema) {
 function items(schema, editorView) {
   return [
     headingMenuItem(schema),
-    select(headingMenuSelectOptions(schema), editorView),
+    select(headingMenuSelectOptions(schema), editorView, "headingSelect"),
     bulletListMenuItem(schema),
     orderedListMenuItem(schema),
     stepsMenuItem(schema),
     linkMenuItem(schema),
     emailLinkMenuItem(schema),
-    select(textBlockMenuSelectOptions(schema), editorView),
+    select(textBlockMenuSelectOptions(schema), editorView, "textBlockSelect"),
+    select(insertMenuSelectOptions(schema), editorView, "insertSelect"),
     undoMenuItem(schema),
     redoMenuItem(schema),
   ];

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -46,5 +46,18 @@
 
 .menubar .govuk-select {
   min-width: 0;
+  margin: 0 10px 0 5px;
+}
+
+.menubar .headingSelect {
+  width: 48px;
+}
+
+.menubar .textBlockSelect {
+  width: 154px;
   margin-right: 5px;
+}
+
+.menubar .insertSelect {
+  width: 82px;
 }


### PR DESCRIPTION
- Add an insert menu with placeholder items for images and attachments for testing next week.
- Manually set the width of the selects to ensure that the visual editor toolbar fits on one line.

https://trello.com/c/YZpwh0xp/2601-insert-element-menu-component

## Screenshot
<img width="811" alt="Screenshot 2024-05-17 at 11 39 54" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/2e1410ce-8da0-43b8-b947-bb6edf488773">
