### PR TITLE
Change lists to be tight

### DIFF
--- a/lib/__snapshots__/markdown.test.js.snap
+++ b/lib/__snapshots__/markdown.test.js.snap
@@ -35,3 +35,12 @@ exports[`Links and email links 1`] = `
 
 [link](mailto:contact@example.com)"
 `;
+
+exports[`Steps 1`] = `
+"s1. step1
+s2. step2
+s3. step3
+
+
+"
+`;

--- a/lib/markdown.test.js
+++ b/lib/markdown.test.js
@@ -11,6 +11,7 @@ const {
   information_callout,
   warning_callout,
   link,
+  steps,
 } = builders(schema);
 
 test("Custom nodes", () => {
@@ -32,6 +33,12 @@ test("Links and email links", () => {
     p(link({ href: "mailto:contact@example.com" }, "contact@example.com")),
     p(link({ href: "mailto:contact@example.com" }, "link")),
   );
+
+  expect(markdownSerializer.serialize(state)).toMatchSnapshot();
+});
+
+test("Steps", () => {
+  const state = doc(steps(p("step1"), p("step2"), p("step3")));
 
   expect(markdownSerializer.serialize(state)).toMatchSnapshot();
 });

--- a/lib/nodes/bullet_list.js
+++ b/lib/nodes/bullet_list.js
@@ -3,18 +3,17 @@ export const name = "bullet_list";
 export const schema = {
   content: "list_item+",
   group: "block",
-  attrs: { tight: { default: false } },
+  attrs: { tight: { default: true } },
   parseDOM: [
     {
       tag: "ul",
-      getAttrs: (dom) => ({ tight: dom.hasAttribute("data-tight") }),
     },
   ],
   toDOM(node) {
-    return ["ul", { "data-tight": node.attrs.tight ? "true" : null }, 0];
+    return ["ul", 0];
   },
 };
 
 export const toGovspeak = (state, node) => {
-  state.renderList(node, "  ", () => (node.attrs.bullet || "*") + " ");
+  state.renderList(node, "", () => (node.attrs.bullet || "*") + " ");
 };

--- a/lib/nodes/ordered_list.js
+++ b/lib/nodes/ordered_list.js
@@ -3,30 +3,17 @@ export const name = "ordered_list";
 export const schema = {
   content: "list_item+",
   group: "block",
-  attrs: { order: { default: 1 } },
+  attrs: { tight: { default: true } },
   parseDOM: [
     {
       tag: "ol",
-      getAttrs(dom) {
-        return {
-          order: dom.hasAttribute("start") ? +dom.getAttribute("start") : 1,
-        };
-      },
     },
   ],
   toDOM(node) {
-    return node.attrs.order === 1
-      ? ["ol", 0]
-      : ["ol", { start: node.attrs.order }, 0];
+    return ["ol", 0];
   },
 };
 
 export const toGovspeak = (state, node) => {
-  const start = node.attrs.order || 1;
-  const maxW = String(start + node.childCount - 1).length;
-  const space = state.repeat(" ", maxW + 2);
-  state.renderList(node, space, (i) => {
-    const nStr = String(start + i);
-    return state.repeat(" ", maxW - nStr.length) + nStr + ". ";
-  });
+  state.renderList(node, "", (i) => `${i + 1}. `);
 };

--- a/lib/nodes/steps.js
+++ b/lib/nodes/steps.js
@@ -5,6 +5,7 @@ export const name = "steps";
 export const schema = {
   content: "list_item+",
   group: "block",
+  attrs: { tight: { default: true } },
   parseDOM: [
     {
       tag: "ol.steps",


### PR DESCRIPTION
Steps numbering was not being persisted in govspeak, so we added tight as default. For consistency, we also changed the behaviour of bullet and ordered lists to be tight as well.


[Trello](https://trello.com/c/JvU1z2Qf/2483-apply-return-key-press-behaviour-for-visual-editor)