### PR TITLE
Make toolbar "sticky"

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -21,12 +21,23 @@
 }
 
 .menubar {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   background: #f3f2f1;
   margin-bottom: 0;
   width: 100%;
   box-sizing: border-box;
   padding: 10px;
   align-items: center;
+  box-shadow: 0 2px 0 0 black;
+}
+
+.menubar:has(+ .ProseMirror:focus) {
+  box-shadow:
+    inset 0 -3px 0 0 #fd0,
+    0 4px 0 0 black,
+    0 -6px 0 3px white;
 }
 
 .menubar .govuk-button {


### PR DESCRIPTION
## What
- Use `position: sticky` to ensure that the menubar stays at the top of the screen.
- Use box shadows to simulate the textinput outlines.

## Why
- It's a pain for users if they need to scroll up and down the page to use the toolbar

https://trello.com/c/OzSVdrDN/2634-make-editor-toolbar-sticky