### PR TITLE
Use the title attribute of links to display URL

### DIFF
--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -12,7 +12,7 @@ export const schema = {
       getAttrs(dom) {
         return {
           href: dom.getAttribute("href"),
-          title: dom.getAttribute("title"),
+          title: dom.getAttribute("href"), // TODO: change back to title when we support that
         };
       },
     },
@@ -32,12 +32,7 @@ export const serializerSpec = {
     state.inEmail = undefined;
     return inEmail
       ? ">"
-      : "](" +
-          mark.attrs.href.replace(/[()"]/g, "\\$&") +
-          (mark.attrs.title
-            ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"`
-            : "") +
-          ")";
+      : "](" + mark.attrs.href.replace(/[()"]/g, "\\$&") + ")";
   },
   mixable: true,
 };


### PR DESCRIPTION
Whilst we don't have a menu for links, use the title attribute to display the URL