### PR TITLE
Add versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,36 @@ jobs:
 
   vitest:
     uses: ./.github/workflows/vitest.yml
+
+  release:
+    needs: vitest
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - name: Establish version
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          echo "::set-output name=local::${LOCAL}"
+          echo "::set-output name=remote::$(npm view govspeak-visual-editor version)"
+          if git ls-remote --tags --exit-code origin ${LOCAL}; then
+            echo "::set-output name=tagged::yes"
+          fi
+        id: version
+      - name: Tag version
+        if: ${{ steps.version.outputs.tagged != 'yes' }}
+        run: git tag ${{ steps.version.outputs.local }} && git push --tags
+      - name: Release to NPM
+        if: ${{ steps.version.outputs.local != steps.version.outputs.remote }}
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.ALPHAGOV_NPM_AUTOMATION_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+- We use the [GOV.UK versioning guidelines](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#versioning).
+- Mark breaking changes with `BREAKING:`. Be sure to include instructions on how applications should be upgraded.
+- Include a link to your pull request.
+- Don't include changes that are purely internal. The CHANGELOG should be a useful summary for people upgrading their
+  application, not a replication of the commit log.
+
+## Unreleased
+
+## 1.0.5
+
+- Initial publishing of package to npm

--- a/README.md
+++ b/README.md
@@ -55,3 +55,37 @@ Each 'node' file in that directory defines a few things:
 [NodeSpec]: https://prosemirror.net/docs/ref/#model.NodeSpec
 [prosemirror-model]: https://prosemirror.net/docs/ref/#model
 [prosemirror-inputrules]: https://prosemirror.net/docs/ref/#inputrules
+
+## Making changes
+
+You should keep track of relevant unreleased changed by adding to the `Unreleased` section of the `CHANGELOG.md`.
+
+## Publishing to npm
+
+1. Checkout **main** and pull latest changes.
+
+2. Create and checkout a new branch (`release-[version-number]`).
+   The version number is determined by looking at the [current "Unreleased" changes in CHANGELOG](/CHANGELOG.md) and updating the previous release number depending on the kind of entries:
+
+- `Breaking changes` corresponds to a `major` (1.X.X) change.
+- `New features` corresponds to a `minor` (X.1.X) change.
+- `Fixes` corresponds to a `patch` (X.X.1) change.
+
+For example if the previous version is `2.3.0` and there are entries for `Breaking changes` then the new release should be `3.0.0`.
+See [Semantic Versioning](https://semver.org/) for more information.
+
+3. Update [`CHANGELOG.md`](/CHANGELOG.md) "Unreleased" heading with the new version number and [review the latest commits](https://github.com/alphagov/govspeak-visual-editor/commits/main/) to make sure the latest changes are correctly reflected in the [CHANGELOG](<(/CHANGELOG.md)>).
+
+4. Update [`package.json`](/package.json) version with the new version number.
+
+5. Run `npm install` to ensure you have the latest dependencies installed.
+
+6. Commit changes. These should include updates in the following files:
+
+- [`CHANGELOG.md`](/CHANGELOG.md)
+- [`package.json`](/package.json)
+- [`package-lock.json`](/package-lock.json)
+
+7. Create a pull request and copy the changelog text for the current version in the pull request description.
+
+8. Once the pull request is approved, merge into the `main` branch. This action will trigger the CI to publish the new version to NPM. A [dependabot](https://github.com/dependabot) pull request will automatically be raised in relevant applications.


### PR DESCRIPTION
Introduce versioning for the package:
- add a CHANGELOG
- update README to include instructions for publishing to NPM


[Trello](https://trello.com/c/PhgX6wzC/2540-distribute-the-govspeak-visual-editor-via-node-package-manager)