### PR TITLE
Reuse workflow for publishing package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,33 +34,8 @@ jobs:
 
   release:
     needs: vitest
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-      - run: npm run build
-      - name: Establish version
-        run: |
-          LOCAL=$(node -p "require('./package.json').version")
-          echo "::set-output name=local::${LOCAL}"
-          echo "::set-output name=remote::$(npm view govspeak-visual-editor version)"
-          if git ls-remote --tags --exit-code origin ${LOCAL}; then
-            echo "::set-output name=tagged::yes"
-          fi
-        id: version
-      - name: Tag version
-        if: ${{ steps.version.outputs.tagged != 'yes' }}
-        run: git tag ${{ steps.version.outputs.local }} && git push --tags
-      - name: Release to NPM
-        if: ${{ steps.version.outputs.local != steps.version.outputs.remote }}
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.ALPHAGOV_NPM_AUTOMATION_TOKEN }}
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-npm-package.yml@main
+    with:
+      deploy_to_github_pages: false
+    secrets:
+      NODE_AUTH_TOKEN: ${{ secrets.ALPHAGOV_NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
Extracted the publishing of the package into a reusable workflow in `govuk-infrastructure` repo. 
Pulling that in and passing through the `ALPHAGOV_NPM_AUTOMATION_TOKEN` as a param. 
The `package_name` input in the workflow defaults to the name of the repo. 
Setting the `deploy_to_github_pages` to false as we have not set that up yet.

[Trello card](https://trello.com/c/M6YhKwFP/2665-add-npm-package-publish-workflow-to-govuk-infrastructure)