### PR TITLE
Release 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+## 1.0.6
+
+- Remove the dist folder ([PR here](https://github.com/alphagov/govspeak-visual-editor/pull/69))
+
 ## 1.0.5
 
 - Initial publishing of package to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govspeak-visual-editor",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govspeak-visual-editor",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "govuk-frontend": "^4.8.0",
         "prosemirror-example-setup": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govspeak-visual-editor",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
# Changelog

## 1.0.6
- Remove the dist folder ([PR here](https://github.com/alphagov/govspeak-visual-editor/pull/69))