### PR TITLE
Move custom plugins into their own files

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,36 +1,20 @@
 import { exampleSetup } from "prosemirror-example-setup";
-import { inputRules } from "prosemirror-inputrules";
-import { Plugin } from "prosemirror-state";
-import nodeDefinitions from "./nodes";
+import customInputRules from "./plugins/custom-input-rules";
+import editorGovspeakClass from "./plugins/editor-govspeak-class";
 import menu from "./plugins/menu";
 
-const customInputRules = (schema) => {
-  const rules = nodeDefinitions
-    .filter((node) => typeof node.inputRules !== "undefined")
-    .flatMap((node) => node.inputRules(schema));
-  return inputRules({ rules });
-};
-
 export default (options) => {
+  const plugins = [
+    customInputRules(options.schema),
+    editorGovspeakClass,
+    menu(options.schema),
+  ];
+
   options.menuBar = false;
-  const plugins = exampleSetup(options);
-
+  const examplePlugins = exampleSetup(options);
   // Remove the "ProseMirror-example-setup-style" class name plugin
-  plugins.pop();
-
-  // Add "govspeak" class name to the editor
-  plugins.push(
-    new Plugin({
-      props: {
-        attributes: { class: "govspeak" },
-      },
-    }),
-  );
-
-  // Input rules for custom nodes
-  plugins.push(customInputRules(options.schema));
-
-  plugins.push(menu(options.schema));
+  examplePlugins.pop();
+  plugins.push(...examplePlugins);
 
   return plugins;
 };

--- a/lib/plugins/custom-input-rules.js
+++ b/lib/plugins/custom-input-rules.js
@@ -1,0 +1,9 @@
+import nodeDefinitions from "../nodes";
+import { inputRules } from "prosemirror-inputrules";
+
+export default function customInputRules(schema) {
+  const rules = nodeDefinitions
+    .filter((node) => typeof node.inputRules !== "undefined")
+    .flatMap((node) => node.inputRules(schema));
+  return inputRules({ rules });
+}

--- a/lib/plugins/editor-govspeak-class.js
+++ b/lib/plugins/editor-govspeak-class.js
@@ -1,0 +1,7 @@
+import { Plugin } from "prosemirror-state";
+
+export default new Plugin({
+  props: {
+    attributes: { class: "govspeak" },
+  },
+});


### PR DESCRIPTION
Normalise plugin definitions to all have their own file imported into `plugins.js`. Import these first then add the example setup.

This will make extending additional plugins more explicit and easier to navigate