### PR TITLE
Make Shift+Enter operate like Enter key

### DIFF
--- a/e2e/lists.spec.js
+++ b/e2e/lists.spec.js
@@ -45,7 +45,7 @@ test.describe("bulleted list", () => {
     await page.keyboard.type("test 1");
     await page.keyboard.press("Enter");
     await page.keyboard.type("test 2");
-    await page.keyboard.press("Enter");
+    await page.keyboard.press("Shift+Enter");
     await page.keyboard.type("test 3");
     await page.keyboard.press("Enter");
     await page.keyboard.press("Enter");
@@ -127,7 +127,7 @@ test.describe("numbered list", () => {
     await page.keyboard.type("test 1");
     await page.keyboard.press("Enter");
     await page.keyboard.type("test 2");
-    await page.keyboard.press("Enter");
+    await page.keyboard.press("Shift+Enter");
     await page.keyboard.type("test 3");
     await page.keyboard.press("Enter");
     await page.keyboard.press("Enter");
@@ -207,7 +207,7 @@ test.describe("steps", () => {
     await page.keyboard.type("Step test 1");
     await page.keyboard.press("Enter");
     await page.keyboard.type("Step test 2");
-    await page.keyboard.press("Enter");
+    await page.keyboard.press("Shift+Enter");
     await page.keyboard.type("Step test 3");
     await page.keyboard.press("Enter");
     await page.keyboard.press("Enter");

--- a/e2e/menu_items_block/addresses.spec.js
+++ b/e2e/menu_items_block/addresses.spec.js
@@ -86,9 +86,11 @@ test("should produce expected markdown honouring multiple spacing for Enter and 
     .selectOption("Address");
   await page.getByText("New line").selectText();
   await page.keyboard.type("Address line 1");
-  await page.keyboard.press("Shift+Enter");
-  await page.keyboard.press("Shift+Enter");
+  await page.keyboard.press("Enter");
   await page.keyboard.type("Address line 2");
+  await page.keyboard.press("Shift+Enter");
+  await page.keyboard.press("Shift+Enter");
+  await page.keyboard.type("Address line 3");
   await page.keyboard.press("Shift+Enter");
   await page.keyboard.press("Shift+Enter");
   await page.keyboard.press("Shift+Enter");
@@ -104,11 +106,14 @@ test("should produce expected markdown honouring multiple spacing for Enter and 
     page.locator("#editor .address").getByText("Address line 2"),
   ).toBeVisible();
   await expect(
+    page.locator("#editor .address").getByText("Address line 3"),
+  ).toBeVisible();
+  await expect(
     page.locator("#editor .address").getByText("Not address"),
   ).not.toBeVisible();
 
   expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
-    /\$A\nAddress line 1\n\nAddress line 2\n\n\$A/,
+    /\$A\nAddress line 1\nAddress line 2\n\nAddress line 3\n\n\$A/,
   );
 });
 

--- a/e2e/menu_items_block/blockquote.spec.js
+++ b/e2e/menu_items_block/blockquote.spec.js
@@ -61,6 +61,8 @@ test("should render blockquote in the editor on multiple lines clearing on doubl
   await page.keyboard.type("Blockquote line 1");
   await page.keyboard.press("Enter");
   await page.keyboard.type("Blockquote line 2");
+  await page.keyboard.press("Shift+Enter");
+  await page.keyboard.type("Blockquote line 3");
   await page.keyboard.press("Enter");
   await page.keyboard.press("Enter");
   await page.keyboard.type("Not blockquote");
@@ -72,11 +74,14 @@ test("should render blockquote in the editor on multiple lines clearing on doubl
     page.locator("#editor blockquote").getByText("Blockquote line 2"),
   ).toBeVisible();
   await expect(
+    page.locator("#editor blockquote").getByText("Blockquote line 3"),
+  ).toBeVisible();
+  await expect(
     page.locator("#editor blockquote").getByText("Not blockquote"),
   ).not.toBeVisible();
 
   expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
-    /> Blockquote line 1\n>\n> Blockquote line 2\n\nNot blockquote/,
+    /> Blockquote line 1\n>\n> Blockquote line 2\n>\n> Blockquote line 3\n\nNot blockquote/,
   );
 });
 

--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -66,6 +66,8 @@ test("should render call to action in the editor on multiple lines clearing on d
   await page.keyboard.type("Action 1");
   await page.keyboard.press("Enter");
   await page.keyboard.type("Action 2");
+  await page.keyboard.press("Shift+Enter");
+  await page.keyboard.type("Action 3");
   await page.keyboard.press("Enter");
   await page.keyboard.press("Enter");
   await page.keyboard.type("Not action");
@@ -78,11 +80,14 @@ test("should render call to action in the editor on multiple lines clearing on d
     page.locator("#editor .call-to-action").getByText("Action 2"),
   ).toBeVisible();
   await expect(
+    page.locator("#editor .call-to-action").getByText("Action 3"),
+  ).toBeVisible();
+  await expect(
     page.locator("#editor .call-to-action").getByText("Not action"),
   ).not.toBeVisible();
 
   expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
-    /\$CTA\n\nAction 1\n\nAction 2\n\n\$CTA\n\nNot action/,
+    /\$CTA\n\nAction 1\n\nAction 2\n\nAction 3\n\n\$CTA\n\nNot action/,
   );
 });
 

--- a/lib/plugins/custom-keymap.js
+++ b/lib/plugins/custom-keymap.js
@@ -1,5 +1,7 @@
 import { Selection } from "prosemirror-state";
 import { keymap } from "prosemirror-keymap";
+import { baseKeymap, chainCommands } from "prosemirror-commands";
+import { splitListItem } from "prosemirror-schema-list";
 
 const parentIsType = (type, head) => {
   const parentDepth = head.depth - 1;
@@ -27,12 +29,15 @@ const replaceHardBreakWithParagraph = (position, schema, state) => {
     .scrollIntoView();
 };
 
-const newlineInAddress = (schema) => {
+const newlineInAddress = (schema, attributes) => {
   return (state, dispatch) => {
     const { $head } = state.selection;
     if (!parentIsType(schema.nodes.address, $head)) return false;
 
-    if (positionIsAtEndAfterHardBreak($head, schema)) {
+    if (
+      attributes.exitEndOfBlock &&
+      positionIsAtEndAfterHardBreak($head, schema)
+    ) {
       dispatch(replaceHardBreakWithParagraph($head.after(), schema, state));
       return false; // Let default handler lift the new paragraph out of the address
     }
@@ -45,10 +50,16 @@ const newlineInAddress = (schema) => {
 };
 
 export default function customKeymap(schema) {
+  const modifiedEnterBehaviour = chainCommands(
+    newlineInAddress(schema, { exitEndOfBlock: false }),
+    splitListItem(schema.nodes.list_item),
+    baseKeymap.Enter,
+  );
+
   return keymap({
-    "Shift-Enter": false,
-    "Mod-Enter": false,
-    "Ctrl-Enter": false,
-    Enter: newlineInAddress(schema),
+    "Shift-Enter": modifiedEnterBehaviour,
+    "Mod-Enter": modifiedEnterBehaviour,
+    "Ctrl-Enter": modifiedEnterBehaviour,
+    Enter: newlineInAddress(schema, { exitEndOfBlock: true }),
   });
 }


### PR DESCRIPTION
Shift+Enter was breaking for quite a few of other components outside of Address. 

Current problems:

Shift+Enter for list items renders differently on GovSpeak than the visual editor

<img width="1400" alt="Screenshot 2024-06-05 at 15 38 07" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/94d56e80-8b7f-4e8b-8152-761ba9379adc">
<img width="473" alt="Screenshot 2024-06-05 at 15 38 33" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/980ef7a4-83b0-49c2-b208-21fde1bdc0f1">


Shift+Enter introduces new lines in CTA and other blocks that are unsupported by GovSpeak so they render differently

<img width="1138" alt="Screenshot 2024-06-05 at 15 39 45" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/00688cf4-72b5-45b2-8ea5-24776c2f8677">
<img width="495" alt="Screenshot 2024-06-05 at 15 39 58" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/a178e5a8-886e-4655-9e42-daf32188de8e">


This PR:

Fixes the issues by making Shift+Enter and other Mod+Enter keys behave like Enter on most components, and split list items. Allow users to add extra lines in between address blocks using Shift+Enter, as well as exit the block with double enter. Enter and Shift+Enter should also not break any other components

After the fix: 
<img width="1320" alt="Screenshot 2024-06-05 at 15 41 59" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/b3286543-8335-4e7b-a8cd-d3207e4586f0">

https://trello.com/c/JvU1z2Qf/2483-apply-return-key-press-behaviour-for-visual-editor
