### PR TITLE
Remove formatting options not available for Whitehall content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Remove contact; example, information and warning callouts; and steps from the toolbar.
+
 ## 1.0.6
 
 - Remove the dist folder ([PR here](https://github.com/alphagov/govspeak-visual-editor/pull/69))

--- a/e2e/lists.spec.js
+++ b/e2e/lists.spec.js
@@ -10,12 +10,7 @@ test.describe("bulleted list", () => {
     await page.getByTitle("Ordered list").click();
     await expect(page.locator(".menubar")).toBeVisible();
     const enabledMenuButtons = [];
-    const disabledMenuButtons = [
-      "Heading 2",
-      "Bullet list",
-      "Ordered list",
-      "Steps",
-    ];
+    const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByTitle(button)).toBeEnabled();
@@ -88,12 +83,7 @@ test.describe("numbered list", () => {
     await page.getByTitle("Bullet list").click();
     await expect(page.locator(".menubar")).toBeVisible();
     const enabledMenuButtons = [];
-    const disabledMenuButtons = [
-      "Heading 2",
-      "Bullet list",
-      "Ordered list",
-      "Steps",
-    ];
+    const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByTitle(button)).toBeEnabled();
@@ -166,23 +156,6 @@ test.describe("numbered list", () => {
 });
 
 test.describe("steps", () => {
-  test("renders steps menu items", async ({ page }) => {
-    await page.getByTitle("Steps").click();
-    await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = [];
-    const disabledMenuButtons = [
-      "Heading 2",
-      "Bullet list",
-      "Ordered list",
-      "Steps",
-    ];
-
-    for (const button of enabledMenuButtons)
-      await expect(page.getByTitle(button)).toBeEnabled();
-    for (const button of disabledMenuButtons)
-      await expect(page.getByTitle(button)).toBeDisabled();
-  });
-
   test("loads steps from the index file in the editor", async ({ page }) => {
     await expect(
       page.locator("#editor ol.steps li").getByText("Step 1"),
@@ -195,15 +168,10 @@ test.describe("steps", () => {
     ).toBeVisible();
   });
 
-  test("should render steps in the editor clearing on double enter when clicking on 's1.' and typing", async ({
+  test("should render steps in the editor and clear on double enter", async ({
     page,
   }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("New line\n");
-
-    await page.getByText("New line").click();
-    await page.getByTitle("Steps").click();
-    await page.getByText("New line").selectText();
+    await page.locator("#editor ol.steps").selectText();
     await page.keyboard.type("Step test 1");
     await page.keyboard.press("Enter");
     await page.keyboard.type("Step test 2");
@@ -229,18 +197,5 @@ test.describe("steps", () => {
     expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
       /s1\. Step test 1\ns2\. Step test 2\ns3\. Step test 3\n\n\nNot steps/,
     );
-  });
-
-  test("should toggle steps item for existing paragraph line", async ({
-    page,
-  }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing steps\n");
-
-    await page.locator("#editor p").getByText("Testing steps").click();
-    await page.getByTitle("Steps").click();
-    await expect(
-      page.locator("#editor ol.steps li").getByText("Testing steps"),
-    ).toBeVisible();
   });
 });

--- a/e2e/menu_items_block/addresses.spec.js
+++ b/e2e/menu_items_block/addresses.spec.js
@@ -18,7 +18,6 @@ test("renders address menu items with expected disabled states", async ({
     "Email link",
     "Bullet list",
     "Ordered list",
-    "Steps",
   ];
   const disabledMenuButtons = ["Heading 2"];
 
@@ -27,16 +26,8 @@ test("renders address menu items with expected disabled states", async ({
   for (const button of disabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-  const enabledSelectOptions = [
-    "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Contact",
-    "Address",
-    "Blockquote",
-  ];
-  const disabledSelectOptions = ["H3", "H4", "H5", "H6"];
+  const enabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+  const disabledSelectOptions = ["H3", "H4"];
 
   for (const option of enabledSelectOptions)
     await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();

--- a/e2e/menu_items_block/blockquote.spec.js
+++ b/e2e/menu_items_block/blockquote.spec.js
@@ -14,12 +14,7 @@ test("renders blockquote menu items with expected disabled states", async ({
   await expect(page.locator(".menubar")).toBeVisible();
 
   const enabledMenuButtons = ["Link", "Email link"];
-  const disabledMenuButtons = [
-    "Heading 2",
-    "Bullet list",
-    "Ordered list",
-    "Steps",
-  ];
+  const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -30,13 +25,7 @@ test("renders blockquote menu items with expected disabled states", async ({
   const disabledSelectOptions = [
     "H3",
     "H4",
-    "H5",
-    "H6",
     "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Contact",
     "Address",
     "Blockquote",
   ];

--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -16,7 +16,6 @@ test("renders blockquote menu items with expected disabled states", async ({
   const enabledMenuButtons = [
     "Bullet list",
     "Ordered list",
-    "Steps",
     "Link",
     "Email link",
   ];
@@ -27,16 +26,8 @@ test("renders blockquote menu items with expected disabled states", async ({
   for (const button of disabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-  const enabledSelectOptions = [
-    "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Contact",
-    "Address",
-    "Blockquote",
-  ];
-  const disabledSelectOptions = ["H3", "H4", "H5", "H6"];
+  const enabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+  const disabledSelectOptions = ["H3", "H4"];
 
   for (const option of enabledSelectOptions)
     await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();

--- a/e2e/menu_items_block/contacts.spec.js
+++ b/e2e/menu_items_block/contacts.spec.js
@@ -5,21 +5,20 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
+test("loads contacts from the index file in the editor", async ({ page }) => {
+  await expect(
+    page.locator("#editor .contact").getByText("Financial Conduct Authority"),
+  ).toBeVisible();
+});
+
 test("renders contact menu items with expected disabled states", async ({
   page,
 }) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Contact");
+  await page.locator("#editor .contact").click();
   await expect(page.locator(".menubar")).toBeVisible();
 
   const enabledMenuButtons = ["Link", "Email link"];
-  const disabledMenuButtons = [
-    "Heading 2",
-    "Bullet list",
-    "Ordered list",
-    "Steps",
-  ];
+  const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -30,13 +29,7 @@ test("renders contact menu items with expected disabled states", async ({
   const disabledSelectOptions = [
     "H3",
     "H4",
-    "H5",
-    "H6",
     "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Contact",
     "Address",
     "Blockquote",
   ];
@@ -47,23 +40,10 @@ test("renders contact menu items with expected disabled states", async ({
     await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
 });
 
-test("loads contacts from the index file in the editor", async ({ page }) => {
-  await expect(
-    page.locator("#editor .contact").getByText("Financial Conduct Authority"),
-  ).toBeVisible();
-});
-
-test("should render contact in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
+test("should render contact in the editor on multiple lines clearing on double enter", async ({
   page,
 }) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("New line\n");
-
-  await page.getByText("New line").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Contact");
-  await page.getByText("New line").selectText();
+  await page.locator("#editor .contact").selectText();
   await page.keyboard.type("Contact line 1\nContact line 2\n\nNot contact\n");
 
   await expect(
@@ -75,16 +55,4 @@ test("should render contact in the editor on multiple lines clearing on double e
   await expect(
     page.locator("#editor .contact").getByText("Not contact"),
   ).not.toBeVisible();
-});
-
-test("should toggle contact for existing paragraph line", async ({ page }) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing paragraph\n");
-  await page.locator("#editor p").getByText("Testing paragraph").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Contact");
-  await expect(
-    page.locator("#editor .contact").getByText("Testing paragraph"),
-  ).toBeVisible();
 });

--- a/e2e/menu_items_block/example_callouts.spec.js
+++ b/e2e/menu_items_block/example_callouts.spec.js
@@ -5,18 +5,23 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
+test("loads example callout from the index file in the editor", async ({
+  page,
+}) => {
+  await expect(
+    page.locator("#editor .example").getByText("This is an example callout"),
+  ).toBeVisible();
+});
+
 test("renders example callout menu items with expected disabled states", async ({
   page,
 }) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Example callout");
+  await page.locator("#editor .example").click();
   await expect(page.locator(".menubar")).toBeVisible();
 
   const enabledMenuButtons = [
     "Bullet list",
     "Ordered list",
-    "Steps",
     "Link",
     "Email link",
   ];
@@ -27,16 +32,8 @@ test("renders example callout menu items with expected disabled states", async (
   for (const button of disabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-  const enabledSelectOptions = [
-    "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Contact",
-    "Address",
-    "Blockquote",
-  ];
-  const disabledSelectOptions = ["H3", "H4", "H5", "H6"];
+  const enabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+  const disabledSelectOptions = ["H3", "H4"];
 
   for (const option of enabledSelectOptions)
     await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
@@ -44,25 +41,10 @@ test("renders example callout menu items with expected disabled states", async (
     await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
 });
 
-test("loads example callout from the index file in the editor", async ({
-  page,
-}) => {
-  await expect(
-    page.locator("#editor .example").getByText("This is an example callout"),
-  ).toBeVisible();
-});
-
 test("should render example callout in the editor on multiple lines clearing on double enter when clicking on '$A' and typing", async ({
   page,
 }) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("New line\n");
-
-  await page.getByText("New line").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Example callout");
-  await page.getByText("New line").selectText();
+  await page.locator("#editor .example").selectText();
   await page.keyboard.type("Example 1\nExample 2\n\nNot example\n");
 
   await expect(
@@ -76,39 +58,16 @@ test("should render example callout in the editor on multiple lines clearing on 
   ).not.toBeVisible();
 });
 
-test.fixme(
-  "should toggle example callout for existing paragraph line",
-  async ({ page }) => {
-    await page.locator("#editor .ProseMirror.govspeak").focus();
-    await page.keyboard.type("Testing paragraph\n");
-
-    await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page
-      .locator('select:has-text("Add text block")')
-      .selectOption("Example callout");
-    await expect(
-      page.locator("#editor .example").getByText("Testing paragraph"),
-    ).toBeVisible();
-  },
-);
-
 test("should allow embedding of other content", async ({ page }) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Example callout");
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing example callout\n\n");
+  await page.locator("#editor .example").selectText();
 
   await page
-    .locator("#editor .example")
-    .getByText("Testing example callout")
-    .click();
-  await page
     .locator('select:has-text("Add text block")')
-    .selectOption("Example callout");
+    .selectOption("Call to action");
+
   await expect(
     page
-      .locator("#editor .example .example")
-      .getByText("Testing example callout"),
+      .locator("#editor .example .call-to-action")
+      .getByText("This is an example callout"),
   ).toBeVisible();
 });

--- a/e2e/menu_items_inline/headings.spec.js
+++ b/e2e/menu_items_inline/headings.spec.js
@@ -10,12 +10,20 @@ test.describe("H2", () => {
     await page.getByTitle("Heading 2").click();
     await expect(page.locator(".menubar")).toBeVisible();
     const enabledMenuButtons = ["Heading 2"];
-    const disabledMenuButtons = ["Bullet list", "Ordered list", "Steps"];
+    const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByTitle(button)).toBeEnabled();
     for (const button of disabledMenuButtons)
       await expect(page.getByTitle(button)).toBeDisabled();
+
+    const enabledSelectOptions = ["H3", "H4"];
+    const disabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+
+    for (const option of enabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+    for (const option of disabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
   });
 
   test("loads H2 from the index file in the editor", async ({ page }) => {
@@ -70,28 +78,27 @@ test.describe("H2", () => {
   });
 });
 
-test.fixme("H3", () => {
+test.describe("H3", () => {
   test("renders H3 menu items with expected disabled state", async ({
     page,
   }) => {
-    await page.getByText("H3", { exact: true }).click();
+    await page.locator('select:has-text("H")').first().selectOption("H3");
     await expect(page.locator(".menubar")).toBeVisible();
-    const visibleMenuButtons = ["p", "H2", "^", "%"];
-    const disabledMenuButtons = [
-      "H3",
-      "1.",
-      "-",
-      "“”",
-      "$A",
-      "$CTA",
-      "$C",
-      "$E",
-    ];
+    const enabledMenuButtons = ["Heading 2"];
+    const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
-    for (const button of visibleMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeVisible();
+    for (const button of enabledMenuButtons)
+      await expect(page.getByTitle(button)).toBeEnabled();
     for (const button of disabledMenuButtons)
-      await expect(page.getByText(button, { exact: true })).toBeDisabled();
+      await expect(page.getByTitle(button)).toBeDisabled();
+
+    const enabledSelectOptions = ["H3", "H4"];
+    const disabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+
+    for (const option of enabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+    for (const option of disabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
   });
 
   test("loads H3 from the index file in the editor", async ({ page }) => {
@@ -107,7 +114,7 @@ test.fixme("H3", () => {
     await page.keyboard.type("New line\n");
 
     await page.getByText("New line").click();
-    await page.getByText("H3", { exact: true }).click();
+    await page.locator('select:has-text("H")').first().selectOption("H3");
     await page.getByText("New line").selectText();
     await page.keyboard.type("Testing H3!\nTesting not H3!\n");
     await expect(
@@ -125,7 +132,7 @@ test.fixme("H3", () => {
     await page.keyboard.type("Testing paragraph\n");
 
     await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByText("H3", { exact: true }).click();
+    await page.locator('select:has-text("H")').first().selectOption("H3");
     await expect(
       page.locator("#editor h3").getByText("Testing paragraph"),
     ).toBeVisible();
@@ -134,12 +141,12 @@ test.fixme("H3", () => {
   test("should toggle H3 headings off for existing heading", async ({
     page,
   }) => {
-    await page.getByText("H3", { exact: true }).click();
+    await page.locator('select:has-text("H")').first().selectOption("H3");
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("Testing heading\n");
 
     await page.locator("#editor h3").getByText("Testing heading").click();
-    await page.getByText("p", { exact: true }).click();
+    await page.locator('select:has-text("H")').first().selectOption("H3");
     await expect(
       page.locator("#editor p").getByText("Testing heading"),
     ).toBeVisible();

--- a/e2e/menu_items_inline/information_callouts.spec.js
+++ b/e2e/menu_items_inline/information_callouts.spec.js
@@ -5,41 +5,6 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders information callout menu items with expected disabled states", async ({
-  page,
-}) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Information callout");
-  await expect(page.locator(".menubar")).toBeVisible();
-
-  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
-  const disabledMenuButtons = ["Bullet list", "Ordered list", "Steps"];
-
-  for (const button of enabledMenuButtons)
-    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
-  for (const button of disabledMenuButtons)
-    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
-
-  const enabledSelectOptions = [
-    "H3",
-    "H4",
-    "H5",
-    "H6",
-    "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Address",
-  ];
-  const disabledSelectOptions = ["Contact", "Blockquote"];
-
-  for (const option of enabledSelectOptions)
-    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
-  for (const option of disabledSelectOptions)
-    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
-});
-
 test("loads information callouts from the index file in the editor", async ({
   page,
 }) => {
@@ -50,17 +15,33 @@ test("loads information callouts from the index file in the editor", async ({
   ).toBeVisible();
 });
 
-test("should render information callouts in the editor and clear style after new line when clicking on 'Information callout' and typing", async ({
+test("renders information callout menu items with expected disabled states", async ({
   page,
 }) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("New line\n");
+  await page.locator("#editor .info-notice").click();
+  await expect(page.locator(".menubar")).toBeVisible();
 
-  await page.getByText("New line").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Information callout");
-  await page.getByText("New line").selectText();
+  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
+  const disabledMenuButtons = ["Bullet list", "Ordered list"];
+
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
+
+  const enabledSelectOptions = ["H3", "H4", "Call to action", "Address"];
+  const disabledSelectOptions = ["Blockquote"];
+
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
+
+test("should render information callouts in the editor and clear style after new line", async ({
+  page,
+}) => {
+  await page.locator("#editor .info-notice").selectText();
   await page.keyboard.type(
     "Testing information callout!\nTesting not information callout!\n",
   );
@@ -74,40 +55,4 @@ test("should render information callouts in the editor and clear style after new
       .locator("#editor .info-notice")
       .getByText("Testing not information callout!"),
   ).not.toBeVisible();
-});
-
-test("should toggle information callout for existing paragraph line", async ({
-  page,
-}) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing paragraph\n");
-
-  await page.locator("#editor p").getByText("Testing paragraph").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Information callout");
-  await expect(
-    page.locator("#editor .info-notice").getByText("Testing paragraph"),
-  ).toBeVisible();
-});
-
-test("should toggle information callout off for existing callout", async ({
-  page,
-}) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Information callout");
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing information callout\n");
-
-  await page
-    .locator("#editor .info-notice")
-    .getByText("Testing information callout")
-    .click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Information callout");
-  await expect(
-    page.locator("#editor p").getByText("Testing information callout"),
-  ).toBeVisible();
 });

--- a/e2e/menu_items_inline/warning_callouts.spec.js
+++ b/e2e/menu_items_inline/warning_callouts.spec.js
@@ -5,41 +5,6 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test("renders warning callout menu items with expected disabled states", async ({
-  page,
-}) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Warning callout");
-  await expect(page.locator(".menubar")).toBeVisible();
-
-  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
-  const disabledMenuButtons = ["Bullet list", "Ordered list", "Steps"];
-
-  for (const button of enabledMenuButtons)
-    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
-  for (const button of disabledMenuButtons)
-    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
-
-  const enabledSelectOptions = [
-    "H3",
-    "H4",
-    "H5",
-    "H6",
-    "Call to action",
-    "Information callout",
-    "Warning callout",
-    "Example callout",
-    "Address",
-  ];
-  const disabledSelectOptions = ["Contact", "Blockquote"];
-
-  for (const option of enabledSelectOptions)
-    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
-  for (const option of disabledSelectOptions)
-    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
-});
-
 test("loads warning callouts from the index file in the editor", async ({
   page,
 }) => {
@@ -48,17 +13,33 @@ test("loads warning callouts from the index file in the editor", async ({
   ).toBeVisible();
 });
 
-test("should render warning callouts in the editor and clear style after new line when selecting 'Warning callout' and typing", async ({
+test("renders warning callout menu items with expected disabled states", async ({
   page,
 }) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("New line\n");
+  await page.locator("#editor .help-notice").click();
+  await expect(page.locator(".menubar")).toBeVisible();
 
-  await page.getByText("New line").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Warning callout");
-  await page.getByText("New line").selectText();
+  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
+  const disabledMenuButtons = ["Bullet list", "Ordered list"];
+
+  for (const button of enabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
+  for (const button of disabledMenuButtons)
+    await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
+
+  const enabledSelectOptions = ["H3", "H4", "Call to action", "Address"];
+  const disabledSelectOptions = ["Blockquote"];
+
+  for (const option of enabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+  for (const option of disabledSelectOptions)
+    await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
+});
+
+test("should render warning callouts in the editor and clear style after new line", async ({
+  page,
+}) => {
+  await page.locator("#editor .help-notice").selectText();
   await page.keyboard.type(
     "Testing warning callout!\nTesting not warning callout!\n",
   );
@@ -70,40 +51,4 @@ test("should render warning callouts in the editor and clear style after new lin
       .locator("#editor .help-notice")
       .getByText("Testing not warning callout!"),
   ).not.toBeVisible();
-});
-
-test("should toggle warning callout for existing paragraph line", async ({
-  page,
-}) => {
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing paragraph\n");
-
-  await page.locator("#editor p").getByText("Testing paragraph").click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Warning callout");
-  await expect(
-    page.locator("#editor .help-notice").getByText("Testing paragraph"),
-  ).toBeVisible();
-});
-
-test("should toggle warning callout off for existing callout", async ({
-  page,
-}) => {
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Warning callout");
-  await page.locator("#editor .ProseMirror.govspeak").focus();
-  await page.keyboard.type("Testing warning callout\n");
-
-  await page
-    .locator("#editor .help-notice")
-    .getByText("Testing warning callout")
-    .click();
-  await page
-    .locator('select:has-text("Add text block")')
-    .selectOption("Warning callout");
-  await expect(
-    page.locator("#editor p").getByText("Testing warning callout"),
-  ).toBeVisible();
 });

--- a/lib/nodes/contact.js
+++ b/lib/nodes/contact.js
@@ -1,5 +1,3 @@
-import { wrappingInputRule } from "prosemirror-inputrules";
-
 export const name = "contact";
 
 export const schema = {
@@ -11,11 +9,6 @@ export const schema = {
     return ["div", { class: "contact" }, ["p", 0]];
   },
 };
-
-export const inputRules = (schema) => [
-  // $C Contact
-  wrappingInputRule(/^\$C\s$/, schema.nodes[name]),
-];
 
 export const toGovspeak = (state, node) => {
   state.write("$C\n\n");

--- a/lib/nodes/example_callout.js
+++ b/lib/nodes/example_callout.js
@@ -1,5 +1,3 @@
-import { wrappingInputRule } from "prosemirror-inputrules";
-
 export const name = "example_callout";
 
 export const schema = {
@@ -11,11 +9,6 @@ export const schema = {
     return ["div", { class: "example" }, 0];
   },
 };
-
-export const inputRules = (schema) => [
-  // $E Example callout
-  wrappingInputRule(/^\$E\s$/, schema.nodes[name]),
-];
 
 export const toGovspeak = (state, node) => {
   state.write("$E\n\n");

--- a/lib/nodes/information_callout.js
+++ b/lib/nodes/information_callout.js
@@ -1,5 +1,3 @@
-import { textblockTypeInputRule } from "prosemirror-inputrules";
-
 export const name = "information_callout";
 
 export const schema = {
@@ -15,11 +13,6 @@ export const schema = {
     return ["div", { class: "application-notice info-notice" }, ["p", 0]];
   },
 };
-
-export const inputRules = (schema) => [
-  // ^ Information callout
-  textblockTypeInputRule(/^\^\s$/, schema.nodes[name]),
-];
 
 export const toGovspeak = (state, node) => {
   state.write("^");

--- a/lib/nodes/steps.js
+++ b/lib/nodes/steps.js
@@ -1,5 +1,3 @@
-import { wrappingInputRule } from "prosemirror-inputrules";
-
 export const name = "steps";
 
 export const schema = {
@@ -15,11 +13,6 @@ export const schema = {
     return ["ol", { class: "steps" }, 0];
   },
 };
-
-export const inputRules = (schema) => [
-  // s1. steps
-  wrappingInputRule(/^s1.\s$/, schema.nodes[name]),
-];
 
 export const toGovspeak = (state, node) => {
   state.renderList(node, "", (i) => {

--- a/lib/nodes/warning_callout.js
+++ b/lib/nodes/warning_callout.js
@@ -1,5 +1,3 @@
-import { textblockTypeInputRule } from "prosemirror-inputrules";
-
 export const name = "warning_callout";
 
 export const schema = {
@@ -15,11 +13,6 @@ export const schema = {
     return ["div", { class: "application-notice help-notice" }, ["p", 0]];
   },
 };
-
-export const inputRules = (schema) => [
-  // % Warning callout
-  textblockTypeInputRule(/^%\s$/, schema.nodes[name]),
-];
 
 export const toGovspeak = (state, node) => {
   state.write("%");

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -11,7 +11,6 @@ import MenuPluginView from "./menu-plugin-view";
 import headingIconUrl from "../icons/heading.svg";
 import bulletListIconUrl from "../icons/bullet-list.svg";
 import orderedListIconUrl from "../icons/ordered-list.svg";
-import stepsIconUrl from "../icons/steps.svg";
 import linkIconUrl from "../icons/link.svg";
 import emailLinkIconUrl from "../icons/email-link.svg";
 import undoIconUrl from "../icons/undo.svg";
@@ -88,20 +87,6 @@ function headingMenuSelectOptions(schema) {
         setBlockType(schema.nodes.paragraph),
       ),
     },
-    {
-      text: "H5",
-      command: chainCommands(
-        setBlockType(schema.nodes.heading, { level: 5 }),
-        setBlockType(schema.nodes.paragraph),
-      ),
-    },
-    {
-      text: "H6",
-      command: chainCommands(
-        setBlockType(schema.nodes.heading, { level: 6 }),
-        setBlockType(schema.nodes.paragraph),
-      ),
-    },
   ];
 }
 
@@ -116,13 +101,6 @@ function orderedListMenuItem(schema) {
   return {
     command: wrapInList(schema.nodes.ordered_list),
     dom: button("Ordered list", orderedListIconUrl),
-  };
-}
-
-function stepsMenuItem(schema) {
-  return {
-    command: wrapInList(schema.nodes.steps),
-    dom: button("Steps", stepsIconUrl),
   };
 }
 
@@ -190,28 +168,6 @@ function textBlockMenuSelectOptions(schema) {
       command: wrapIn(schema.nodes.call_to_action),
     },
     {
-      text: "Information callout",
-      command: chainCommands(
-        setBlockType(schema.nodes.information_callout),
-        setBlockType(schema.nodes.paragraph),
-      ),
-    },
-    {
-      text: "Warning callout",
-      command: chainCommands(
-        setBlockType(schema.nodes.warning_callout),
-        setBlockType(schema.nodes.paragraph),
-      ),
-    },
-    {
-      text: "Example callout",
-      command: wrapIn(schema.nodes.example_callout),
-    },
-    {
-      text: "Contact",
-      command: wrapIn(schema.nodes.contact),
-    },
-    {
       text: "Address",
       command: wrapIn(schema.nodes.address),
     },
@@ -259,7 +215,6 @@ function items(schema, editorView) {
     select(headingMenuSelectOptions(schema), editorView, "heading-select"),
     bulletListMenuItem(schema),
     orderedListMenuItem(schema),
-    stepsMenuItem(schema),
     linkMenuItem(schema),
     emailLinkMenuItem(schema),
     select(textBlockMenuSelectOptions(schema), editorView, "text-block-select"),


### PR DESCRIPTION
We do not want to encourage the use of components outside of the Whitehall guidance. This PR removes the ability to create such components in the Visual Editor but does not remove them from the schema as they will be needed to support the editing of existing documents.

Testing is supported by loading the HTML for the components from `index.html`.

https://trello.com/c/uFIcDuGP/2676-remove-formatting-options-not-available-for-whitehall-content

## Screenshot
<img width="678" alt="Screenshot 2024-06-05 at 15 37 00" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/741740b5-33c6-482b-b587-835e95acab29">
