### PR TITLE
Fix backspace for list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ## Unreleased
 
 - Remove contact; example, information and warning callouts; and steps from the toolbar.
+- Fix: address format and rendering
+- Fix: linebreak and backspace for new list items
 
 ## 1.0.6
 

--- a/e2e/lists.spec.js
+++ b/e2e/lists.spec.js
@@ -28,7 +28,7 @@ test.describe("bulleted list", () => {
     ).toBeVisible();
   });
 
-  test("should render bullet list in the editor clearing on double enter when clicking on '-' and typing", async ({
+  test("should render bullet list in the editor clearing on double enter", async ({
     page,
   }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
@@ -61,6 +61,32 @@ test.describe("bulleted list", () => {
 
     expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
       /\* test 1\n\* test 2\n\* test 3\n\nNot list/,
+    );
+  });
+
+  test("should jump back onto previous list item when pressing backspace on an empty list item", async ({
+    page,
+  }) => {
+    await page.locator("#editor .ProseMirror.govspeak").focus();
+    await page.keyboard.type("New line\n");
+
+    await page.getByText("New line").click();
+    await page.getByTitle("Bullet list").click();
+    await page.getByText("New line").selectText();
+    await page.keyboard.type("test 1");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type(" extra");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Not list");
+
+    await expect(
+      page.locator("#editor ul li").getByText("test 1 extra"),
+    ).toBeVisible();
+
+    expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
+      /\* test 1 extra\n\nNot list/,
     );
   });
 
@@ -105,7 +131,7 @@ test.describe("numbered list", () => {
     ).toBeVisible();
   });
 
-  test("should render numbered list in the editor clearing on double enter when clicking on '1.' and typing", async ({
+  test("should render numbered list in the editor clearing on double enter", async ({
     page,
   }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
@@ -141,6 +167,32 @@ test.describe("numbered list", () => {
     );
   });
 
+  test("should jump back onto previous list item when pressing backspace on an empty list item", async ({
+    page,
+  }) => {
+    await page.locator("#editor .ProseMirror.govspeak").focus();
+    await page.keyboard.type("New line\n");
+
+    await page.getByText("New line").click();
+    await page.getByTitle("Ordered list").click();
+    await page.getByText("New line").selectText();
+    await page.keyboard.type("test 1");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type(" extra");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Not list");
+
+    await expect(
+      page.locator("#editor ol li").getByText("test 1 extra"),
+    ).toBeVisible();
+
+    expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
+      /1\. test 1 extra\n\nNot list/,
+    );
+  });
+
   test("should toggle numbered list item for existing paragraph line", async ({
     page,
   }) => {
@@ -168,7 +220,7 @@ test.describe("steps", () => {
     ).toBeVisible();
   });
 
-  test("should render steps in the editor and clear on double enter", async ({
+  test("should render steps in the editor clearing on double enter", async ({
     page,
   }) => {
     await page.locator("#editor ol.steps").selectText();
@@ -196,6 +248,27 @@ test.describe("steps", () => {
 
     expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
       /s1\. Step test 1\ns2\. Step test 2\ns3\. Step test 3\n\n\nNot steps/,
+    );
+  });
+
+  test("should jump back onto previous list item when pressing backspace on an empty list item", async ({
+    page,
+  }) => {
+    await page.locator("#editor ol.steps").selectText();
+    await page.keyboard.type("test 1");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type(" extra");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Not list");
+
+    await expect(
+      page.locator("#editor ol.steps li").getByText("test 1 extra"),
+    ).toBeVisible();
+
+    expect(await page.locator("textarea#govspeak").inputValue()).toMatch(
+      /s1\. test 1 extra\n\n\nNot list/,
     );
   });
 });

--- a/lib/plugins/custom-keymap.js
+++ b/lib/plugins/custom-keymap.js
@@ -49,6 +49,31 @@ const newlineInAddress = (schema, attributes) => {
   };
 };
 
+const removeListItem = (schema) => {
+  return (state, dispatch) => {
+    const { $head } = state.selection;
+    if (!parentIsType(schema.nodes.list_item, $head)) return false;
+    if ($head.nodeBefore || $head.nodeAfter) return false;
+
+    const transaction = state.tr;
+    const position = $head.before();
+
+    const beginningOfListItem = position - 2;
+    const endOfPreviousListItem = position - 3;
+
+    dispatch(
+      transaction
+        .deleteRange(beginningOfListItem, $head.after())
+        .setSelection(
+          Selection.near(transaction.doc.resolve(endOfPreviousListItem)),
+          1,
+        )
+        .scrollIntoView(),
+    );
+    return true;
+  };
+};
+
 export default function customKeymap(schema) {
   const modifiedEnterBehaviour = chainCommands(
     newlineInAddress(schema, { exitEndOfBlock: false }),
@@ -61,5 +86,6 @@ export default function customKeymap(schema) {
     "Mod-Enter": modifiedEnterBehaviour,
     "Ctrl-Enter": modifiedEnterBehaviour,
     Enter: newlineInAddress(schema, { exitEndOfBlock: true }),
+    Backspace: removeListItem(schema),
   });
 }


### PR DESCRIPTION
Since we've made the list items tight list as part of this story, when we press backspace, it puts the list in a broken state that does not render valid GovSpeak but looks ok on the Visual Editor. 

<img width="1252" alt="Screenshot 2024-06-05 at 16 00 38" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/77a4e617-7046-4bb0-8f86-fc2f095ad2ed">

<img width="632" alt="Screenshot 2024-06-05 at 16 00 53" src="https://github.com/alphagov/govspeak-visual-editor/assets/568730/aa5c236b-ed49-4fec-800f-3779fc350b84">

Fixing this by making backspace delete back to the previous list item. 

However *_NOTE_*: there's still the same issue happening above if you were to press backspace at the beginning of an existing list item rather than an empty item.

https://trello.com/c/JvU1z2Qf/2483-apply-return-key-press-behaviour-for-visual-editor