### PR TITLE
Use the title attribute of links to display URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix: address format and rendering
 - Fix: linebreak and backspace for new list items
 - Allow selected text to be linked to an email
+- Fix: Link title tooltip for new links
 
 ## 1.0.6
 

--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -43,6 +43,14 @@ test.describe("Link", () => {
       page.locator("#editor").getByText("example.com", { exact: true }),
     ).toHaveAttribute("href", "example.com");
   });
+
+  test("inserted links have the url as title attribute", async ({ page }) => {
+    page.on("dialog", (dialog) => dialog.accept("example.com"));
+    await page.getByTitle("Link", { exact: true }).click();
+    await expect(
+      page.locator("#editor").getByText("example.com", { exact: true }),
+    ).toHaveAttribute("title", "example.com");
+  });
 });
 
 test.describe("Email link", () => {

--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -18,7 +18,7 @@ export const schema = {
     },
   ],
   toDOM(node) {
-    return ["a", node.attrs];
+    return ["a", { href: node.attrs.href, title: node.attrs.href }]; // TODO: change back to title when we support tooltips
   },
 };
 

--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -12,7 +12,7 @@ export const schema = {
       getAttrs(dom) {
         return {
           href: dom.getAttribute("href"),
-          title: dom.getAttribute("href"), // TODO: change back to title when we support that
+          title: dom.getAttribute("title"),
         };
       },
     },
@@ -32,7 +32,12 @@ export const serializerSpec = {
     state.inEmail = undefined;
     return inEmail
       ? ">"
-      : "](" + mark.attrs.href.replace(/[()"]/g, "\\$&") + ")";
+      : "](" +
+          mark.attrs.href.replace(/[()"]/g, "\\$&") +
+          (mark.attrs.title
+            ? ` "${mark.attrs.title.replace(/"/g, '\\"')}"`
+            : "") +
+          ")";
   },
   mixable: true,
 };


### PR DESCRIPTION
- Revert the previous attempt
- Modify the toDom method for links to use the title as a URL tooltip