### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@
 
 ## Unreleased
 
+## 1.1.0
+
 - Remove contact; example, information and warning callouts; and steps from the toolbar.
 - Fix: address format and rendering
 - Fix: linebreak and backspace for new list items
 - Allow selected text to be linked to an email
 - Fix: Link title tooltip for new links
+- Add licence
 
 ## 1.0.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "govspeak-visual-editor",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govspeak-visual-editor",
-      "version": "1.0.6",
+      "version": "1.1.0",
+      "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^4.8.0",
         "prosemirror-example-setup": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govspeak-visual-editor",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "author": "Government Digital Service",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
# Changelog

- Remove contact; example, information and warning callouts; and steps from the toolbar.
- Fix: address format and rendering
- Fix: linebreak and backspace for new list items
- Allow selected text to be linked to an email
- Fix: Link title tooltip for new links
- Add licence