### PR TITLE
Introduce a link tooltip plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 - Change the behaviour of the heading select.
+- Introduce a link tooltip plugin
 
 ## 1.1.0
 

--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -44,12 +44,17 @@ test.describe("Link", () => {
     ).toHaveAttribute("href", "example.com");
   });
 
-  test("inserted links have the url as title attribute", async ({ page }) => {
-    page.on("dialog", (dialog) => dialog.accept("example.com"));
-    await page.getByTitle("Link", { exact: true }).click();
+  test("A tooltip is displayed with the URL of a link", async ({ page }) => {
     await expect(
-      page.locator("#editor").getByText("example.com", { exact: true }),
-    ).toHaveAttribute("title", "example.com");
+      page.locator(".tooltip").getByText("example.com", { exact: true }),
+    ).not.toBeVisible();
+    await page
+      .locator("#editor")
+      .getByText("Example link", { exact: true })
+      .click();
+    await expect(
+      page.locator(".tooltip").getByText("example.com", { exact: true }),
+    ).toBeVisible();
   });
 });
 

--- a/lib/marks/link.js
+++ b/lib/marks/link.js
@@ -18,7 +18,7 @@ export const schema = {
     },
   ],
   toDOM(node) {
-    return ["a", { href: node.attrs.href, title: node.attrs.href }]; // TODO: change back to title when we support tooltips
+    return ["a", node.attrs];
   },
 };
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,14 +1,16 @@
 import { exampleSetup } from "prosemirror-example-setup";
 import customInputRules from "./plugins/custom-input-rules";
-import editorGovspeakClass from "./plugins/editor-govspeak-class";
 import customKeymap from "./plugins/custom-keymap";
+import editorGovspeakClass from "./plugins/editor-govspeak-class";
+import linkTooltip from "./plugins/link-tooltip";
 import menu from "./plugins/menu";
 
 export default (options) => {
   const plugins = [
     customInputRules(options.schema),
-    editorGovspeakClass,
     customKeymap(options.schema),
+    editorGovspeakClass,
+    linkTooltip(options.schema),
     menu(options.schema),
   ];
 

--- a/lib/plugins/link-tooltip.js
+++ b/lib/plugins/link-tooltip.js
@@ -1,0 +1,37 @@
+import { Plugin } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+function renderTooltip(href) {
+  const tooltipWrapper = document.createElement("div");
+  tooltipWrapper.className = "tooltip-wrapper";
+  const tooltip = document.createElement("div");
+  tooltip.className = "tooltip";
+  const a = document.createElement("a");
+  a.href = href;
+  a.target = "_blank";
+  a.textContent = href;
+  tooltip.appendChild(a);
+  tooltipWrapper.appendChild(tooltip);
+  return tooltipWrapper;
+}
+
+function linkTooltipDecorations(state, schema) {
+  if (!state.selection.empty) return null;
+  const link = state.selection.$head
+    .marks()
+    .find((m) => m.type === schema.marks.link);
+  if (!link) return null;
+  return DecorationSet.create(state.doc, [
+    Decoration.widget(state.selection.from, renderTooltip(link.attrs.href)),
+  ]);
+}
+
+export default function linkTooltip(schema) {
+  return new Plugin({
+    props: {
+      decorations(state) {
+        return linkTooltipDecorations(state, schema);
+      },
+    },
+  });
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -71,3 +71,19 @@
 .menubar .insert-select {
   width: 82px;
 }
+
+.tooltip-wrapper {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  vertical-align: bottom;
+}
+
+.tooltip {
+  position: relative;
+
+  background: white;
+  padding: 5px;
+  border: 2px solid black;
+  width: max-content;
+}


### PR DESCRIPTION
Create a new plugin that uses decorations to display the href of a link when the cursor is within the link. Stop using the title for this purpose.

https://trello.com/c/NoNZpcco/2667-spike-preview-link-url

## Screenshot

<img width="686" alt="Screenshot 2024-06-07 at 16 32 44" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/2950fa24-9b0b-4dab-a7f0-15da5b808c4a">
