### PR TITLE
Change the behaviour of the heading select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Change the behaviour of the heading select.
+
 ## 1.1.0
 
 - Remove contact; example, information and warning callouts; and steps from the toolbar.

--- a/e2e/lists.spec.js
+++ b/e2e/lists.spec.js
@@ -10,12 +10,27 @@ test.describe("bulleted list", () => {
     await page.getByTitle("Ordered list").click();
     await expect(page.locator(".menubar")).toBeVisible();
     const enabledMenuButtons = [];
-    const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
+    const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByTitle(button)).toBeEnabled();
     for (const button of disabledMenuButtons)
       await expect(page.getByTitle(button)).toBeDisabled();
+
+    const enabledSelectOptions = [];
+    const disabledSelectOptions = [
+      "Call to action",
+      "Address",
+      "Blockquote",
+      "Heading 2",
+      "Heading 3",
+      "Heading 4",
+    ];
+
+    for (const option of enabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+    for (const option of disabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
   });
 
   test("loads bullet list from the index file in the editor", async ({
@@ -109,12 +124,27 @@ test.describe("numbered list", () => {
     await page.getByTitle("Bullet list").click();
     await expect(page.locator(".menubar")).toBeVisible();
     const enabledMenuButtons = [];
-    const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
+    const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
       await expect(page.getByTitle(button)).toBeEnabled();
     for (const button of disabledMenuButtons)
       await expect(page.getByTitle(button)).toBeDisabled();
+
+    const enabledSelectOptions = [];
+    const disabledSelectOptions = [
+      "Call to action",
+      "Address",
+      "Blockquote",
+      "Heading 2",
+      "Heading 3",
+      "Heading 4",
+    ];
+
+    for (const option of enabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
+    for (const option of disabledSelectOptions)
+      await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
   });
 
   test("loads numbered list from the index file in the editor", async ({

--- a/e2e/menu_items_block/addresses.spec.js
+++ b/e2e/menu_items_block/addresses.spec.js
@@ -19,7 +19,7 @@ test("renders address menu items with expected disabled states", async ({
     "Bullet list",
     "Ordered list",
   ];
-  const disabledMenuButtons = ["Heading 2"];
+  const disabledMenuButtons = [];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -27,7 +27,7 @@ test("renders address menu items with expected disabled states", async ({
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
   const enabledSelectOptions = ["Call to action", "Address", "Blockquote"];
-  const disabledSelectOptions = ["H3", "H4"];
+  const disabledSelectOptions = ["Heading 2", "Heading 3", "Heading 4"];
 
   for (const option of enabledSelectOptions)
     await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();

--- a/e2e/menu_items_block/blockquote.spec.js
+++ b/e2e/menu_items_block/blockquote.spec.js
@@ -14,7 +14,7 @@ test("renders blockquote menu items with expected disabled states", async ({
   await expect(page.locator(".menubar")).toBeVisible();
 
   const enabledMenuButtons = ["Link", "Email link"];
-  const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
+  const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -23,8 +23,9 @@ test("renders blockquote menu items with expected disabled states", async ({
 
   const enabledSelectOptions = [];
   const disabledSelectOptions = [
-    "H3",
-    "H4",
+    "Heading 2",
+    "Heading 3",
+    "Heading 4",
     "Call to action",
     "Address",
     "Blockquote",

--- a/e2e/menu_items_block/call_to_actions.spec.js
+++ b/e2e/menu_items_block/call_to_actions.spec.js
@@ -19,7 +19,7 @@ test("renders blockquote menu items with expected disabled states", async ({
     "Link",
     "Email link",
   ];
-  const disabledMenuButtons = ["Heading 2"];
+  const disabledMenuButtons = [];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -27,7 +27,7 @@ test("renders blockquote menu items with expected disabled states", async ({
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
   const enabledSelectOptions = ["Call to action", "Address", "Blockquote"];
-  const disabledSelectOptions = ["H3", "H4"];
+  const disabledSelectOptions = ["Heading 2", "Heading 3", "Heading 4"];
 
   for (const option of enabledSelectOptions)
     await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();

--- a/e2e/menu_items_block/contacts.spec.js
+++ b/e2e/menu_items_block/contacts.spec.js
@@ -18,7 +18,7 @@ test("renders contact menu items with expected disabled states", async ({
   await expect(page.locator(".menubar")).toBeVisible();
 
   const enabledMenuButtons = ["Link", "Email link"];
-  const disabledMenuButtons = ["Heading 2", "Bullet list", "Ordered list"];
+  const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -27,8 +27,9 @@ test("renders contact menu items with expected disabled states", async ({
 
   const enabledSelectOptions = [];
   const disabledSelectOptions = [
-    "H3",
-    "H4",
+    "Heading 2",
+    "Heading 3",
+    "Heading 4",
     "Call to action",
     "Address",
     "Blockquote",

--- a/e2e/menu_items_block/example_callouts.spec.js
+++ b/e2e/menu_items_block/example_callouts.spec.js
@@ -25,7 +25,7 @@ test("renders example callout menu items with expected disabled states", async (
     "Link",
     "Email link",
   ];
-  const disabledMenuButtons = ["Heading 2"];
+  const disabledMenuButtons = [];
 
   for (const button of enabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeEnabled();
@@ -33,7 +33,7 @@ test("renders example callout menu items with expected disabled states", async (
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
   const enabledSelectOptions = ["Call to action", "Address", "Blockquote"];
-  const disabledSelectOptions = ["H3", "H4"];
+  const disabledSelectOptions = ["Heading 2", "Heading 3", "Heading 4"];
 
   for (const option of enabledSelectOptions)
     await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();

--- a/e2e/menu_items_inline/headings.spec.js
+++ b/e2e/menu_items_inline/headings.spec.js
@@ -5,11 +5,13 @@ test.beforeEach(async ({ page }) => {
   await page.goto(VISUAL_EDITOR_URL);
 });
 
-test.describe("H2", () => {
-  test("renders H2 menu items", async ({ page }) => {
-    await page.getByTitle("Heading 2").click();
+test.describe("Heading 2", () => {
+  test("renders menu items", async ({ page }) => {
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 2");
     await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = ["Heading 2"];
+    const enabledMenuButtons = [];
     const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
@@ -17,8 +19,13 @@ test.describe("H2", () => {
     for (const button of disabledMenuButtons)
       await expect(page.getByTitle(button)).toBeDisabled();
 
-    const enabledSelectOptions = ["H3", "H4"];
-    const disabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+    const enabledSelectOptions = ["Paragraph", "Heading 3", "Heading 4"];
+    const disabledSelectOptions = [
+      "Heading 2",
+      "Call to action",
+      "Address",
+      "Blockquote",
+    ];
 
     for (const option of enabledSelectOptions)
       await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
@@ -26,20 +33,22 @@ test.describe("H2", () => {
       await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
   });
 
-  test("loads H2 from the index file in the editor", async ({ page }) => {
+  test("loads from the index file in the editor", async ({ page }) => {
     await expect(
       page.locator("#editor H2").getByText("This is an H2 heading"),
     ).toBeVisible();
   });
 
-  test("should render H2 headings in the editor and clear style after new line when clicking on 'H2' and typing", async ({
+  test("should render in the editor and clear style after new line when selecting 'Heading 2' and typing", async ({
     page,
   }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("New line\n");
 
     await page.getByText("New line").click();
-    await page.getByTitle("Heading 2").click();
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 2");
     await page.getByText("New line").selectText();
     await page.keyboard.type("Testing H2!\nTesting not H2!\n");
     await expect(
@@ -50,41 +59,43 @@ test.describe("H2", () => {
     ).not.toBeVisible();
   });
 
-  test("should toggle H2 headings on for existing paragraph line", async ({
-    page,
-  }) => {
+  test("should toggle on for existing paragraph line", async ({ page }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("Testing paragraph\n");
 
     await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.getByTitle("Heading 2").click();
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 2");
     await expect(
       page.locator("#editor h2").getByText("Testing paragraph"),
     ).toBeVisible();
   });
 
-  test("should toggle H2 headings off for existing heading", async ({
-    page,
-  }) => {
-    await page.getByTitle("Heading 2").click();
+  test("should toggle off for existing heading", async ({ page }) => {
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 2");
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("Testing heading\n");
 
     await page.locator("#editor h2").getByText("Testing heading").click();
-    await page.getByTitle("Heading 2").click();
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Paragraph");
     await expect(
       page.locator("#editor p").getByText("Testing heading"),
     ).toBeVisible();
   });
 });
 
-test.describe("H3", () => {
-  test("renders H3 menu items with expected disabled state", async ({
-    page,
-  }) => {
-    await page.locator('select:has-text("H")').first().selectOption("H3");
+test.describe("Heading 3", () => {
+  test("renders menu items with expected disabled state", async ({ page }) => {
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 3");
     await expect(page.locator(".menubar")).toBeVisible();
-    const enabledMenuButtons = ["Heading 2"];
+    const enabledMenuButtons = [];
     const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
     for (const button of enabledMenuButtons)
@@ -92,8 +103,13 @@ test.describe("H3", () => {
     for (const button of disabledMenuButtons)
       await expect(page.getByTitle(button)).toBeDisabled();
 
-    const enabledSelectOptions = ["H3", "H4"];
-    const disabledSelectOptions = ["Call to action", "Address", "Blockquote"];
+    const enabledSelectOptions = ["Paragraph", "Heading 2", "Heading 4"];
+    const disabledSelectOptions = [
+      "Heading 3",
+      "Call to action",
+      "Address",
+      "Blockquote",
+    ];
 
     for (const option of enabledSelectOptions)
       await expect(page.locator(`option:has-text("${option}")`)).toBeEnabled();
@@ -101,54 +117,70 @@ test.describe("H3", () => {
       await expect(page.locator(`option:has-text("${option}")`)).toBeDisabled();
   });
 
-  test("loads H3 from the index file in the editor", async ({ page }) => {
+  test("loads from the index file in the editor", async ({ page }) => {
     await expect(
-      page.locator("#editor H3").getByText("This is an H3 heading"),
+      page.locator("#editor h3").getByText("This is an H3 heading"),
     ).toBeVisible();
   });
 
-  test("should render H3 headings in the editor and clear style after new line when clicking on 'H3' and typing", async ({
+  test("should render in the editor and clear style after new line when clicking on 'Heading 3' and typing", async ({
     page,
   }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("New line\n");
 
     await page.getByText("New line").click();
-    await page.locator('select:has-text("H")').first().selectOption("H3");
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 3");
     await page.getByText("New line").selectText();
-    await page.keyboard.type("Testing H3!\nTesting not H3!\n");
+    await page.keyboard.type("Testing Heading 3!\nTesting not Heading 3!\n");
     await expect(
-      page.locator("#editor h3").getByText("Testing H3!"),
+      page.locator("#editor h3").getByText("Testing Heading 3!"),
     ).toBeVisible();
     await expect(
-      page.locator("#editor h3").getByText("Testing not H3!"),
+      page.locator("#editor h3").getByText("Testing not Heading 3!"),
     ).not.toBeVisible();
   });
 
-  test("should toggle H3 headings on for existing paragraph line", async ({
-    page,
-  }) => {
+  test("should toggle on for existing paragraph line", async ({ page }) => {
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("Testing paragraph\n");
 
     await page.locator("#editor p").getByText("Testing paragraph").click();
-    await page.locator('select:has-text("H")').first().selectOption("H3");
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 3");
     await expect(
       page.locator("#editor h3").getByText("Testing paragraph"),
     ).toBeVisible();
   });
 
-  test("should toggle H3 headings off for existing heading", async ({
-    page,
-  }) => {
-    await page.locator('select:has-text("H")').first().selectOption("H3");
+  test("should toggle off for existing heading", async ({ page }) => {
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 3");
     await page.locator("#editor .ProseMirror.govspeak").focus();
     await page.keyboard.type("Testing heading\n");
 
     await page.locator("#editor h3").getByText("Testing heading").click();
-    await page.locator('select:has-text("H")').first().selectOption("H3");
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Paragraph");
     await expect(
       page.locator("#editor p").getByText("Testing heading"),
     ).toBeVisible();
+  });
+});
+
+test.describe("Select", () => {
+  test("Should update as different heading levels are focused", async ({
+    page,
+  }) => {
+    await expect(page.locator('select:has-text("Paragraph")')).toHaveValue("0");
+    await page.locator("#editor H2").selectText();
+    await expect(page.locator('select:has-text("Paragraph")')).toHaveValue("1");
+    await page.locator("#editor H3").selectText();
+    await expect(page.locator('select:has-text("Paragraph")')).toHaveValue("2");
   });
 });

--- a/e2e/menu_items_inline/information_callouts.spec.js
+++ b/e2e/menu_items_inline/information_callouts.spec.js
@@ -21,7 +21,7 @@ test("renders information callout menu items with expected disabled states", asy
   await page.locator("#editor .info-notice").click();
   await expect(page.locator(".menubar")).toBeVisible();
 
-  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
+  const enabledMenuButtons = ["Link", "Email link"];
   const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
   for (const button of enabledMenuButtons)
@@ -29,7 +29,13 @@ test("renders information callout menu items with expected disabled states", asy
   for (const button of disabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-  const enabledSelectOptions = ["H3", "H4", "Call to action", "Address"];
+  const enabledSelectOptions = [
+    "Heading 2",
+    "Heading 3",
+    "Heading 4",
+    "Call to action",
+    "Address",
+  ];
   const disabledSelectOptions = ["Blockquote"];
 
   for (const option of enabledSelectOptions)

--- a/e2e/menu_items_inline/warning_callouts.spec.js
+++ b/e2e/menu_items_inline/warning_callouts.spec.js
@@ -19,7 +19,7 @@ test("renders warning callout menu items with expected disabled states", async (
   await page.locator("#editor .help-notice").click();
   await expect(page.locator(".menubar")).toBeVisible();
 
-  const enabledMenuButtons = ["Heading 2", "Link", "Email link"];
+  const enabledMenuButtons = ["Link", "Email link"];
   const disabledMenuButtons = ["Bullet list", "Ordered list"];
 
   for (const button of enabledMenuButtons)
@@ -27,7 +27,13 @@ test("renders warning callout menu items with expected disabled states", async (
   for (const button of disabledMenuButtons)
     await expect(page.getByTitle(button, { exact: true })).toBeDisabled();
 
-  const enabledSelectOptions = ["H3", "H4", "Call to action", "Address"];
+  const enabledSelectOptions = [
+    "Heading 2",
+    "Heading 3",
+    "Heading 4",
+    "Call to action",
+    "Address",
+  ];
   const disabledSelectOptions = ["Blockquote"];
 
   for (const option of enabledSelectOptions)

--- a/lib/plugins/menu.js
+++ b/lib/plugins/menu.js
@@ -8,7 +8,6 @@ import { wrapInList } from "prosemirror-schema-list";
 import { redo, undo } from "prosemirror-history";
 import { Plugin } from "prosemirror-state";
 import MenuPluginView from "./menu-plugin-view";
-import headingIconUrl from "../icons/heading.svg";
 import bulletListIconUrl from "../icons/bullet-list.svg";
 import orderedListIconUrl from "../icons/ordered-list.svg";
 import linkIconUrl from "../icons/link.svg";
@@ -27,7 +26,7 @@ function button(title, iconUrl) {
   return button;
 }
 
-function select(options, editorView, className) {
+function selectDom(options, editorView, className, resetOnChange) {
   const select = document.createElement("select");
   select.className = `govuk-select ${className}`;
   options.forEach((o, index) => {
@@ -43,11 +42,15 @@ function select(options, editorView, className) {
       editorView,
     );
     editorView.focus();
-    select.selectedIndex = 0;
+    if (resetOnChange) select.selectedIndex = 0;
   });
+  return select;
+}
+
+function menuSelect(options, editorView, className) {
   return {
     command: chainCommands(...options.map((o) => o.command)),
-    dom: select,
+    dom: selectDom(options, editorView, className, true),
     customHandler: () => {},
     update: (view) => {
       options.forEach((o) => {
@@ -57,35 +60,39 @@ function select(options, editorView, className) {
   };
 }
 
-function headingMenuItem(schema) {
+function headingSelect(options, editorView, className) {
+  const dom = selectDom(options, editorView, className);
   return {
-    command: chainCommands(
-      setBlockType(schema.nodes.heading, { level: 2 }),
-      setBlockType(schema.nodes.paragraph),
-    ),
-    dom: button("Heading 2", headingIconUrl),
+    command: chainCommands(...options.map((o) => o.command)),
+    dom,
+    customHandler: () => {},
+    update: (view) => {
+      const index = view.state.selection.$head.parent.attrs.level || 1;
+      dom.selectedIndex = index - 1;
+      options.forEach((o) => {
+        o.dom.disabled = !o.command(view.state, null, view);
+      });
+    },
   };
 }
 
-function headingMenuSelectOptions(schema) {
+function headingSelectOptions(schema) {
   return [
     {
-      text: "H",
-      command: () => {},
+      text: "Paragraph",
+      command: setBlockType(schema.nodes.paragraph),
     },
     {
-      text: "H3",
-      command: chainCommands(
-        setBlockType(schema.nodes.heading, { level: 3 }),
-        setBlockType(schema.nodes.paragraph),
-      ),
+      text: "Heading 2",
+      command: setBlockType(schema.nodes.heading, { level: 2 }),
     },
     {
-      text: "H4",
-      command: chainCommands(
-        setBlockType(schema.nodes.heading, { level: 4 }),
-        setBlockType(schema.nodes.paragraph),
-      ),
+      text: "Heading 3",
+      command: setBlockType(schema.nodes.heading, { level: 3 }),
+    },
+    {
+      text: "Heading 4",
+      command: setBlockType(schema.nodes.heading, { level: 4 }),
     },
   ];
 }
@@ -232,14 +239,17 @@ function redoMenuItem(schema) {
 
 function items(schema, editorView) {
   return [
-    headingMenuItem(schema),
-    select(headingMenuSelectOptions(schema), editorView, "heading-select"),
+    headingSelect(headingSelectOptions(schema), editorView, "heading-select"),
     bulletListMenuItem(schema),
     orderedListMenuItem(schema),
     linkMenuItem(schema),
     emailLinkMenuItem(schema),
-    select(textBlockMenuSelectOptions(schema), editorView, "text-block-select"),
-    select(insertMenuSelectOptions(schema), editorView, "insert-select"),
+    menuSelect(
+      textBlockMenuSelectOptions(schema),
+      editorView,
+      "text-block-select",
+    ),
+    menuSelect(insertMenuSelectOptions(schema), editorView, "insert-select"),
     undoMenuItem(schema),
     redoMenuItem(schema),
   ];

--- a/scss/example.scss
+++ b/scss/example.scss
@@ -22,12 +22,12 @@ body {
   gap: 20px;
 }
 
-#editor,
-#govspeak {
-  flex: 1;
+#editor {
+  min-width: 750px;
 }
 
 #govspeak {
+  width: 100%;
   padding: 50px 15px 15px;
   font-size: 16px;
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -60,7 +60,7 @@
 }
 
 .menubar .heading-select {
-  width: 48px;
+  width: 120px;
 }
 
 .menubar .text-block-select {


### PR DESCRIPTION
Adjust the heading select such that it allows the user to choose between heading levels and paragraph. Remove the H2 button.
This makes it easier for users to verify that heading levels in the document are in the correct order.

https://trello.com/c/3Do6FC2L/2633-update-heading-dropdown-selectedindex-as-users-navigate

## Screenshot
<img width="768" alt="Screenshot 2024-06-10 at 13 02 01" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/8152d8aa-1cfc-41a1-b94d-eab24f8594b5">
