### PR TITLE
Add linting to the editor

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -4,6 +4,7 @@ import customKeymap from "./plugins/custom-keymap";
 import editorGovspeakClass from "./plugins/editor-govspeak-class";
 import linkTooltip from "./plugins/link-tooltip";
 import menu from "./plugins/menu";
+import lint from "./plugins/lint";
 
 export default (options) => {
   const plugins = [
@@ -12,6 +13,7 @@ export default (options) => {
     editorGovspeakClass,
     linkTooltip(options.schema),
     menu(options.schema),
+    lint(options.schema),
   ];
 
   options.menuBar = false;

--- a/lib/plugins/link-tooltip.js
+++ b/lib/plugins/link-tooltip.js
@@ -5,7 +5,7 @@ function renderTooltip(href) {
   const tooltipWrapper = document.createElement("div");
   tooltipWrapper.className = "tooltip-wrapper";
   const tooltip = document.createElement("div");
-  tooltip.className = "tooltip";
+  tooltip.className = "tooltip govuk-body";
   const a = document.createElement("a");
   a.href = href;
   a.target = "_blank";

--- a/lib/plugins/lint.js
+++ b/lib/plugins/lint.js
@@ -1,0 +1,74 @@
+import { Plugin } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+const wordsToAvoid =
+  /\b(agenda|advancing|collaborate|combating|commit|pledge|countering|deliver|deploy|dialogue|disincentivise|incentivise|empower|facilitate|focusing|foster|impact|initiate|key|leverage|liaise|overarching|progress|promote|robust|slimming down|streamline|strengthening|tackling|transforming|utilise)\b/gi;
+
+function renderTooltip(text) {
+  const tooltipWrapper = document.createElement("div");
+  tooltipWrapper.className = "tooltip-wrapper";
+  const tooltip = document.createElement("div");
+  tooltip.className = "tooltip govuk-body";
+  tooltip.textContent = text;
+  tooltipWrapper.appendChild(tooltip);
+  return tooltipWrapper;
+}
+
+function findProblems(schema, doc) {
+  const problems = [];
+  let lastHeadLevel = null;
+
+  function pushProblem(message, from, to) {
+    problems.push({ message, from, to });
+  }
+
+  doc.descendants((node, pos) => {
+    if (node.isText) {
+      let result;
+      while ((result = wordsToAvoid.exec(node.text)))
+        pushProblem(
+          `Avoid using the word '${result[0]}'`,
+          pos + result.index,
+          pos + result.index + result[0].length,
+        );
+    } else if (node.type === schema.nodes.heading) {
+      const level = node.attrs.level;
+      if (lastHeadLevel != null && level > lastHeadLevel + 1)
+        pushProblem(
+          `Heading level skipped (${level} under ${lastHeadLevel})`,
+          pos + 1,
+          pos + 1 + node.content.size,
+        );
+      lastHeadLevel = level;
+    }
+  });
+
+  return problems;
+}
+
+function lintDecorations(state, schema) {
+  const decorations = [];
+  findProblems(schema, state.doc).forEach((problem) => {
+    decorations.push(
+      Decoration.inline(problem.from, problem.to, {
+        class: "problem",
+      })
+    );
+    if ((problem.from <= state.selection.from) && (problem.to >= state.selection.to)) {
+      decorations.push(
+        Decoration.widget(state.selection.from, renderTooltip(problem.message))
+      );
+    };
+  });
+  return DecorationSet.create(state.doc, decorations);
+}
+
+export default function lint(schema) {
+  return new Plugin({
+    props: {
+      decorations(state) {
+        return lintDecorations(state, schema);
+      },
+    },
+  });
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -80,10 +80,18 @@
 }
 
 .tooltip {
+  z-index: 1;
+
   position: relative;
 
   background: white;
   padding: 5px;
   border: 2px solid black;
   width: max-content;
+}
+
+.problem {
+  background: #fdd;
+  border-bottom: 2px solid #f22;
+  margin-bottom: -2px;
 }


### PR DESCRIPTION
Introduce a linting plugin to hightlight when a user uses a word in the "words to avoid" list and when they skip heading levels.

## Screenshots

<img width="771" alt="Screenshot 2024-06-10 at 14 19 13" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/14be5371-b375-49bc-92c6-9bbf3864977e">
<img width="770" alt="Screenshot 2024-06-10 at 14 20 12" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/9393d3ef-d704-4a11-b9d4-2a47fcb4ce6b">
