### PR TITLE
Adjustments to tooltip styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Small adjustments to link tooltips
+
 ## 1.3.0
 
 - GA4 tracking added to buttons

--- a/lib/plugins/link-tooltip.js
+++ b/lib/plugins/link-tooltip.js
@@ -5,11 +5,12 @@ function renderTooltip(href) {
   const tooltipWrapper = document.createElement("div");
   tooltipWrapper.className = "tooltip-wrapper";
   const tooltip = document.createElement("div");
-  tooltip.className = "tooltip";
+  tooltip.className = "tooltip govuk-body";
+  tooltip.textContent = href.startsWith("mailto:") ? "Email: " : "Link: ";
   const a = document.createElement("a");
   a.href = href;
   a.target = "_blank";
-  a.textContent = href;
+  a.textContent = href.startsWith("mailto:") ? href.slice(7) : href;
   tooltip.appendChild(a);
   tooltipWrapper.appendChild(tooltip);
   return tooltipWrapper;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -80,10 +80,18 @@
 }
 
 .tooltip {
-  position: relative;
+  z-index: 1;
+
+  position: absolute;
 
   background: white;
   padding: 5px;
   border: 2px solid black;
+  display: flex;
   width: max-content;
+  max-width: 60%;
+}
+
+.tooltip a {
+  word-break: break-all;
 }


### PR DESCRIPTION
- Display "Link: " or "Email: " in the tooltip
- Strip mailto: from the href
- Set a max-width on the tooltip

## Screenshot
<img width="771" alt="Screenshot 2024-06-12 at 15 28 00" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/6ed618c3-8831-47bd-b619-df3085f7ddad">
