### PR TITLE
Emit event when dropdown select changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 - Small adjustments to link tooltips
+- Add tracking events to dropdown selects
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -97,4 +97,9 @@ GA4 tracking data attributes have been added to the following components of the 
 
 - Toolbar button clicks
 
+The following events are emitted from the Visual Editor. Please add an event handler to any parent wrapper to handle the event for tracking purposes.
+
+- `visualEditorSelectChange` - emitted when select values change on dropdowns in the toolbar. Details sent with the event can be accessed via:
+  - `event.detail.selectText` which returns the text of the selected option in the dropdown
+
 **Please note**: data-module `ga4-event-tracker` needs to be initialised in the parent application that is importing the visual editor for this tracking to work.

--- a/lib/plugins/menu/buttons.js
+++ b/lib/plugins/menu/buttons.js
@@ -7,7 +7,7 @@ import linkIconUrl from "../../icons/link.svg";
 import emailLinkIconUrl from "../../icons/email-link.svg";
 import undoIconUrl from "../../icons/undo.svg";
 import redoIconUrl from "../../icons/redo.svg";
-import { trackButton } from "../../tracking/google-analytics.js";
+import { trackButton } from "../../tracking/google-analytics";
 
 function button(title, iconUrl) {
   const button = document.createElement("button");

--- a/lib/plugins/menu/buttons.js
+++ b/lib/plugins/menu/buttons.js
@@ -7,26 +7,14 @@ import linkIconUrl from "../../icons/link.svg";
 import emailLinkIconUrl from "../../icons/email-link.svg";
 import undoIconUrl from "../../icons/undo.svg";
 import redoIconUrl from "../../icons/redo.svg";
-
-const ga4Attributes = (buttonText) => {
-  return {
-    event_name: "select_content",
-    Type: "tabs",
-    text: buttonText,
-    external: "false",
-    method: "primary click",
-    section: document.title,
-    action: "select",
-    tool_name: "Visual Editor",
-  };
-};
+import { trackButton } from "../../tracking/google-analytics.js";
 
 function button(title, iconUrl) {
   const button = document.createElement("button");
   button.className = "govuk-button govuk-button--secondary";
   button.type = "button";
   button.title = title;
-  button.setAttribute("data-ga4-event", JSON.stringify(ga4Attributes(title)));
+  trackButton(button);
   const icon = document.createElement("img");
   icon.src = iconUrl;
   button.appendChild(icon);

--- a/lib/plugins/menu/dropdowns.js
+++ b/lib/plugins/menu/dropdowns.js
@@ -1,4 +1,5 @@
 import { chainCommands, setBlockType, wrapIn } from "prosemirror-commands";
+import { dispatchSelectTrackingEvent } from "../../tracking/google-analytics";
 
 function selectDom(options, editorView, className, resetOnChange) {
   const select = document.createElement("select");
@@ -16,6 +17,7 @@ function selectDom(options, editorView, className, resetOnChange) {
       editorView,
     );
     editorView.focus();
+    dispatchSelectTrackingEvent(select);
     if (resetOnChange) select.selectedIndex = 0;
   });
   return select;

--- a/lib/tracking/google-analytics-buttons.test.js
+++ b/lib/tracking/google-analytics-buttons.test.js
@@ -6,8 +6,8 @@ import {
   orderedListMenuItem,
   redoMenuItem,
   undoMenuItem,
-} from "./buttons.js";
-import schema from "../../schema";
+} from "../plugins/menu/buttons";
+import schema from "../schema";
 
 test("GA4 Tracking is set for bulletList button", () => {
   const bulletListButton = bulletListMenuItem(schema);

--- a/lib/tracking/google-analytics-dropdowns.test.js
+++ b/lib/tracking/google-analytics-dropdowns.test.js
@@ -1,0 +1,49 @@
+import { test, vi, expect } from "vitest";
+import schema from "../schema";
+import {
+  headingDropdown,
+  insertDropdown,
+  textBlockDropdown,
+} from "../plugins/menu/dropdowns";
+
+test("Tracking event emitted for heading dropdown", () => {
+  const selectDom = headingDropdown(schema, mockEditorView).dom;
+  assertSelectChangeTriggersVisualEditorEvent(selectDom);
+});
+
+test("Tracking event emitted for text block dropdown", () => {
+  const selectDom = textBlockDropdown(schema, mockEditorView).dom;
+  assertSelectChangeTriggersVisualEditorEvent(selectDom);
+});
+
+test("Tracking event emitted for insert dropdown", () => {
+  const selectDom = insertDropdown(schema, mockEditorView).dom;
+  assertSelectChangeTriggersVisualEditorEvent(selectDom);
+});
+
+const assertSelectChangeTriggersVisualEditorEvent = (selectDom) => {
+  let selectChangeEvent;
+  document.addEventListener("visualEditorSelectChange", (event) => {
+    selectChangeEvent = event;
+  });
+  document.body.appendChild(selectDom);
+
+  selectDom.value = 2;
+  selectDom.dispatchEvent(new Event("change"));
+
+  expect(selectChangeEvent).not.toBeNull();
+  expect(selectChangeEvent.detail.selectText).toBe(selectDom.options[2].text);
+};
+
+const mockEditorView = {
+  state: {
+    selection: {
+      ranges: [],
+      $from: {
+        blockRange: vi.fn(),
+      },
+      $to: {},
+    },
+  },
+  focus: vi.fn(),
+};

--- a/lib/tracking/google-analytics.js
+++ b/lib/tracking/google-analytics.js
@@ -1,0 +1,17 @@
+
+const buttonTrackingAttributes = (buttonText) => {
+    return JSON.stringify({
+      event_name: "select_content",
+      Type: "tabs",
+      text: buttonText,
+      external: "false",
+      method: "primary click",
+      section: document.title,
+      action: "select",
+      tool_name: "Visual Editor",
+    });
+}
+
+export const trackButton = (button) => {
+  button.setAttribute("data-ga4-event", buttonTrackingAttributes(button.title));
+}

--- a/lib/tracking/google-analytics.js
+++ b/lib/tracking/google-analytics.js
@@ -1,17 +1,27 @@
-
 const buttonTrackingAttributes = (buttonText) => {
-    return JSON.stringify({
-      event_name: "select_content",
-      Type: "tabs",
-      text: buttonText,
-      external: "false",
-      method: "primary click",
-      section: document.title,
-      action: "select",
-      tool_name: "Visual Editor",
-    });
-}
+  return JSON.stringify({
+    event_name: "select_content",
+    Type: "tabs",
+    text: buttonText,
+    external: "false",
+    method: "primary click",
+    section: document.title,
+    action: "select",
+    tool_name: "Visual Editor",
+  });
+};
 
 export const trackButton = (button) => {
   button.setAttribute("data-ga4-event", buttonTrackingAttributes(button.title));
-}
+};
+
+export const dispatchSelectTrackingEvent = (select) => {
+  select.dispatchEvent(
+    new CustomEvent("visualEditorSelectChange", {
+      bubbles: true,
+      detail: {
+        selectText: select.options[select.selectedIndex].text,
+      },
+    }),
+  );
+};


### PR DESCRIPTION
We are emitting this event to be handled by parent applications importing the Visual Editor. 
This makes it flexible for the applications to handle the events and track data in their own ways.

https://trello.com/c/R7GujwJ3/2684-add-ga4-tracking-to-dropdowns-in-the-toolbar