### PR TITLE
Add remove to link tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Add remove button to link tooltip
+
 ## 1.4.0
 
 - Small adjustments to link tooltips

--- a/e2e/menu_items_inline/links.spec.js
+++ b/e2e/menu_items_inline/links.spec.js
@@ -60,6 +60,17 @@ test.describe("Link", () => {
         .getByText("example.com", { exact: true }),
     ).toBeVisible();
   });
+
+  test("Links can be removed using the tooltip", async ({ page }) => {
+    await page
+      .locator("#editor")
+      .getByText("Example link", { exact: true })
+      .click();
+    await page.getByText("Remove link", { exact: true }).click();
+    await expect(
+      page.locator("#editor").getByText("Example link", { exact: true }),
+    ).not.toHaveAttribute("href");
+  });
 });
 
 test.describe("Email link", () => {

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -1,0 +1,14 @@
+export default class Tooltip {
+  constructor(textContent, ...children) {
+    this.dom = document.createElement("div");
+    this.dom.className = "visual-editor__tooltip-wrapper";
+
+    const tooltip = document.createElement("div");
+    tooltip.className = "visual-editor__tooltip govuk-body";
+    tooltip.textContent = textContent;
+
+    children.forEach((child) => tooltip.appendChild(child));
+
+    this.dom.appendChild(tooltip);
+  }
+}

--- a/lib/plugins/link-tooltip.js
+++ b/lib/plugins/link-tooltip.js
@@ -1,8 +1,9 @@
 import Tooltip from "../components/tooltip";
-import { Plugin } from "prosemirror-state";
+import { toggleMark } from "prosemirror-commands";
+import { Plugin, TextSelection } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
-function renderTooltip(href) {
+function renderTooltip(href, state) {
   const textContent = href.startsWith("mailto:") ? "Email: " : "Link: ";
 
   const a = document.createElement("a");
@@ -11,7 +12,16 @@ function renderTooltip(href) {
   a.target = "_blank";
   a.textContent = href.startsWith("mailto:") ? href.slice(7) : href;
 
-  return new Tooltip(textContent, a).dom;
+  const button = document.createElement("button");
+  button.textContent = "Remove link";
+  button.className =
+    "govuk-body govuk-link visual-editor__tooltip-button visual-editor__tooltip-button--destructive";
+  button.removeLink = true;
+  button.from =
+    state.selection.head - state.selection.$head.nodeBefore.nodeSize;
+  button.to = state.selection.head + state.selection.$head.nodeAfter.nodeSize;
+
+  return new Tooltip(textContent, a, button).dom;
 }
 
 function linkTooltipDecorations(state, schema) {
@@ -21,8 +31,28 @@ function linkTooltipDecorations(state, schema) {
     .find((m) => m.type === schema.marks.link);
   if (!link) return null;
   return DecorationSet.create(state.doc, [
-    Decoration.widget(state.selection.from, renderTooltip(link.attrs.href)),
+    Decoration.widget(
+      state.selection.head,
+      renderTooltip(link.attrs.href, state),
+    ),
   ]);
+}
+
+function maybeRemoveLink(schema, view, event) {
+  if (!event.target.removeLink) {
+    return;
+  }
+
+  const { from, to } = event.target;
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, from, to))
+      .scrollIntoView(),
+  );
+  toggleMark(schema.marks.link)(view.state, view.dispatch);
+  view.focus();
+
+  return true;
 }
 
 export default function linkTooltip(schema) {
@@ -30,6 +60,15 @@ export default function linkTooltip(schema) {
     props: {
       decorations(state) {
         return linkTooltipDecorations(state, schema);
+      },
+      handleKeyDown(view, event) {
+        if (event.keyCode !== 13 && event.keyCode !== 32) {
+          return;
+        }
+        return maybeRemoveLink(schema, view, event);
+      },
+      handleClick(view, _, event) {
+        return maybeRemoveLink(schema, view, event);
       },
     },
   });

--- a/lib/plugins/link-tooltip.js
+++ b/lib/plugins/link-tooltip.js
@@ -1,20 +1,17 @@
+import Tooltip from "../components/tooltip";
 import { Plugin } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
 function renderTooltip(href) {
-  const tooltipWrapper = document.createElement("div");
-  tooltipWrapper.className = "visual-editor__tooltip-wrapper";
-  const tooltip = document.createElement("div");
-  tooltip.className = "visual-editor__tooltip govuk-body";
-  tooltip.textContent = href.startsWith("mailto:") ? "Email: " : "Link: ";
+  const textContent = href.startsWith("mailto:") ? "Email: " : "Link: ";
+
   const a = document.createElement("a");
   a.className = "visual-editor__tooltip-link";
   a.href = href;
   a.target = "_blank";
   a.textContent = href.startsWith("mailto:") ? href.slice(7) : href;
-  tooltip.appendChild(a);
-  tooltipWrapper.appendChild(tooltip);
-  return tooltipWrapper;
+
+  return new Tooltip(textContent, a).dom;
 }
 
 function linkTooltipDecorations(state, schema) {

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -11,7 +11,7 @@
   position: absolute;
 
   background: white;
-  padding: 5px;
+  padding: 5px 10px;
   border: 2px solid black;
   display: flex;
   width: max-content;
@@ -20,4 +20,35 @@
 
 .visual-editor__tooltip-link {
   word-break: break-all;
+}
+
+.visual-editor__tooltip-button {
+  background: none;
+  border: none;
+  margin: 0 0 0 10px;
+  padding: 0;
+  height: fit-content;
+  white-space: nowrap;
+
+  cursor: pointer;
+
+  text-decoration: underline;
+  text-decoration-thickness: max(1px, 0.0625rem);
+  text-underline-offset: 0.1578em;
+}
+
+.visual-editor__tooltip-button:hover {
+  text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+  -webkit-text-decoration-skip-ink: none;
+  text-decoration-skip-ink: none;
+  -webkit-text-decoration-skip: none;
+  text-decoration-skip: none;
+}
+
+.visual-editor__tooltip-button--destructive {
+  color: #d4351c;
+}
+
+.visual-editor__tooltip-button--destructive:hover {
+  color: #bd2f19;
 }


### PR DESCRIPTION
- Refactor tooltip into its own file
- Add button to remove a link to the url tooltip
- Style buttons in the tooltip to appear as links

https://trello.com/c/tB14DuVF/2718-add-remove-to-link-tooltip

## Screenshot
<img width="780" alt="Screenshot 2024-07-04 at 13 13 35" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/28ea26f7-7157-4cdf-9ed8-140363239f87">
