### PR TITLE
Add skipped heading level linting to the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add remove button to link tooltip
 - Fix tabbing through the toolbar in Firefox - [PR](https://github.com/alphagov/govspeak-visual-editor/pull/123)
+- Add skipped heading level linting - [PR #125](https://github.com/alphagov/govspeak-visual-editor/pull/125)
 
 ## 1.4.0
 

--- a/e2e/menu_items_inline/headings.spec.js
+++ b/e2e/menu_items_inline/headings.spec.js
@@ -184,3 +184,43 @@ test.describe("Select", () => {
     await expect(page.locator('select:has-text("Paragraph")')).toHaveValue("2");
   });
 });
+
+test.describe("Linting", () => {
+  test("Should highlight a skipped heading level and provide a tooltip", async ({
+    page,
+  }) => {
+    await page.locator("#editor h3").selectText();
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 4");
+    await expect(
+      page.locator(".visual-editor__highlight--error"),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator(".visual-editor__tooltip")
+        .getByText("Skipped heading from H2 to H4. Consider H3 instead.", {
+          exact: true,
+        }),
+    ).toBeVisible();
+  });
+
+  test("Should expect the first heading in document to be an H2", async ({
+    page,
+  }) => {
+    await page.locator("#editor h2").selectText();
+    await page
+      .locator('select:has-text("Paragraph")')
+      .selectOption("Heading 4");
+    await expect(
+      page.locator(".visual-editor__highlight--error"),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator(".visual-editor__tooltip")
+        .getByText("The first heading in a document must be H2.", {
+          exact: true,
+        }),
+    ).toBeVisible();
+  });
+});

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -3,12 +3,20 @@ export default class Tooltip {
     this.dom = document.createElement("div");
     this.dom.className = "visual-editor__tooltip-wrapper";
 
-    const tooltip = document.createElement("div");
-    tooltip.className = "visual-editor__tooltip govuk-body";
-    tooltip.textContent = textContent;
+    this.tooltip = document.createElement("div");
+    this.tooltip.className = "visual-editor__tooltip govuk-body";
+    this.tooltip.textContent = textContent;
 
-    children.forEach((child) => tooltip.appendChild(child));
+    children.forEach((child) => this.tooltip.appendChild(child));
 
-    this.dom.appendChild(tooltip);
+    this.dom.appendChild(this.tooltip);
+  }
+
+  set error(value) {
+    this.tooltip.classList.toggle("govuk-error-message", value);
+  }
+
+  get error() {
+    return this.tooltip.classList.contains("govuk-error-message");
   }
 }

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -4,6 +4,7 @@ import customKeymap from "./plugins/custom-keymap";
 import editorGovspeakClass from "./plugins/editor-govspeak-class";
 import linkTooltip from "./plugins/link-tooltip";
 import menu from "./plugins/menu/menu";
+import lint from "./plugins/lint";
 
 export default (options) => {
   const plugins = [
@@ -12,6 +13,7 @@ export default (options) => {
     editorGovspeakClass,
     linkTooltip(options.schema),
     menu(options.schema),
+    lint(options.schema),
   ];
 
   options.menuBar = false;

--- a/lib/plugins/lint.js
+++ b/lib/plugins/lint.js
@@ -1,0 +1,59 @@
+import Tooltip from "../components/tooltip";
+import { Plugin } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+function findProblems(schema, doc) {
+  const problems = [];
+  let lastHeadLevel = null;
+
+  doc.descendants((node, pos) => {
+    if (node.type === schema.nodes.heading) {
+      const level = node.attrs.level;
+      if (lastHeadLevel == null && level !== 2) {
+        problems.push({
+          message: `The first heading in a document must be H2.`,
+          from: pos + 1,
+          to: pos + 1 + node.content.size,
+        });
+      } else if (lastHeadLevel !== null && level > lastHeadLevel + 1)
+        problems.push({
+          message: `Skipped heading from H${lastHeadLevel} to H${level}. Consider H${lastHeadLevel + 1} instead.`,
+          from: pos + 1,
+          to: pos + 1 + node.content.size,
+        });
+      lastHeadLevel = level;
+    }
+  });
+
+  return problems;
+}
+
+function lintDecorations(state, schema) {
+  const decorations = [];
+  findProblems(schema, state.doc).forEach((problem) => {
+    decorations.push(
+      Decoration.inline(problem.from, problem.to, {
+        class: "visual-editor__highlight--error",
+      }),
+    );
+    if (
+      problem.from <= state.selection.from &&
+      problem.to >= state.selection.to
+    ) {
+      const tooltip = new Tooltip(problem.message);
+      tooltip.error = true;
+      decorations.push(Decoration.widget(state.selection.from, tooltip.dom));
+    }
+  });
+  return DecorationSet.create(state.doc, decorations);
+}
+
+export default function lint(schema) {
+  return new Plugin({
+    props: {
+      decorations(state) {
+        return lintDecorations(state, schema);
+      },
+    },
+  });
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -3,3 +3,8 @@
 @import "./menu";
 @import "./prosemirror-overrides";
 @import "./tooltip";
+
+.visual-editor__highlight--error {
+  border-bottom: 2px dashed #d4351c;
+  margin-bottom: -2px;
+}

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -15,7 +15,7 @@
   border: 2px solid black;
   display: flex;
   width: max-content;
-  max-width: 60%;
+  max-width: 65%;
 }
 
 .visual-editor__tooltip-link {


### PR DESCRIPTION
## What
- Introduce a linting plugin
- Update tooltip with error styles
- Use the linting plugin and tooltip to highlight when a user skips a heading level

## Why
- Skipped heading levels is something that publishers currently have to manually check
- https://trello.com/c/S5AJ36y7/2717-add-skipped-heading-level-linting-to-the-editor

## Screenshot
<img width="782" alt="Screenshot 2024-07-09 at 09 53 14" src="https://github.com/alphagov/govspeak-visual-editor/assets/9594455/7fc81f75-2862-41ae-8a8e-e7f6568671a6">
