### PR TITLE
Version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+## 1.5.0
+
 - Add remove button to link tooltip
 - Fix tabbing through the toolbar in Firefox - [PR](https://github.com/alphagov/govspeak-visual-editor/pull/123)
 - Add skipped heading level linting - [PR #125](https://github.com/alphagov/govspeak-visual-editor/pull/125)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govspeak-visual-editor",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govspeak-visual-editor",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govspeak-visual-editor",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "Government Digital Service",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
- Add remove button to link tooltip
- Fix tabbing through the toolbar in Firefox - [PR](https://github.com/alphagov/govspeak-visual-editor/pull/123)
- Add skipped heading level linting - [PR #125](https://github.com/alphagov/govspeak-visual-editor/pull/125)