### PR TITLE
Improve deletion of list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Unreleased
 
+- Fix bug with list item deletion
+
 ## 1.5.0
 
 - Add remove button to link tooltip

--- a/e2e/lists.spec.js
+++ b/e2e/lists.spec.js
@@ -105,6 +105,37 @@ test.describe("bulleted list", () => {
     );
   });
 
+  test("should jump back to previous list item when pressing backspace at the start of a list item", async ({
+    page,
+  }) => {
+    await page.locator("#editor .ProseMirror.govspeak").focus();
+    await page.keyboard.type("New line\n");
+
+    await page.getByText("New line").click();
+    await page.getByTitle("Bullet list").click();
+    await page.getByText("New line").selectText();
+    await page.keyboard.type("test 1");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("2");
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.press("Backspace");
+
+    await expect(
+      page.locator("#editor ul li").getByText("test 12"),
+    ).toBeVisible();
+  });
+
+  test("should exit the list when pressing backspace in an empty list", async ({
+    page,
+  }) => {
+    await page.locator("#editor .ProseMirror.govspeak").selectText();
+    await page.keyboard.press("Backspace");
+    await page.getByTitle("Bullet list").click();
+    await expect(page.locator("#editor ul li")).toHaveCount(1);
+    await page.keyboard.press("Backspace");
+    await expect(page.locator("#editor ul li")).toHaveCount(0);
+  });
+
   test("should toggle bullet list item for existing paragraph line", async ({
     page,
   }) => {

--- a/lib/plugins/custom-keymap.js
+++ b/lib/plugins/custom-keymap.js
@@ -1,6 +1,6 @@
 import { Selection } from "prosemirror-state";
 import { keymap } from "prosemirror-keymap";
-import { baseKeymap, chainCommands } from "prosemirror-commands";
+import { baseKeymap, chainCommands, joinBackward } from "prosemirror-commands";
 import { splitListItem } from "prosemirror-schema-list";
 
 const parentIsType = (type, head) => {
@@ -53,24 +53,9 @@ const removeListItem = (schema) => {
   return (state, dispatch) => {
     const { $head } = state.selection;
     if (!parentIsType(schema.nodes.list_item, $head)) return false;
-    if ($head.nodeBefore || $head.nodeAfter) return false;
+    if ($head.nodeBefore) return false;
 
-    const transaction = state.tr;
-    const position = $head.before();
-
-    const beginningOfListItem = position - 2;
-    const endOfPreviousListItem = position - 3;
-
-    dispatch(
-      transaction
-        .deleteRange(beginningOfListItem, $head.after())
-        .setSelection(
-          Selection.near(transaction.doc.resolve(endOfPreviousListItem)),
-          1,
-        )
-        .scrollIntoView(),
-    );
-    return true;
+    return joinBackward(state, dispatch) && joinBackward(state, dispatch);
   };
 };
 


### PR DESCRIPTION
Simplify the custom list item deletion to simply joinBackwards twice - once escaping the list item and a second time to join the paragraph with the previous list item.

This fixes two cases (which now have tests) where it was impossible to delete an empty list and that the custom list deletion didn't apply when the cursor was at the beginning of a list item that wasn't empty.

https://trello.com/c/DM5NyAYp/2744-fix-deletion-of-first-list-item