### PR TITLE
Fix playwright tests

### DIFF
--- a/e2e/images.spec.js
+++ b/e2e/images.spec.js
@@ -29,25 +29,48 @@ test("invalid image from the index file in the editor is displayed with an error
   ).toBeVisible();
 });
 
-test("parses pasted markdown", async ({ page }) => {
-  await expect(page.locator('#editor [src="/example.jpg"]')).toHaveCount(1);
-  await page.locator('#editor [contenteditable="true"]').focus();
-  await page.keyboard.type("[Image: example.jpg]\n");
-  await page.locator("#editor").getByText("[Image: example.jpg]").selectText();
+async function simulatePaste(page, text) {
+  await page.evaluate((text) => {
+    const editor = document.querySelector('#editor [contenteditable="true"]');
+    const clipboardData = new DataTransfer();
+    clipboardData.setData("text/plain", text);
+    const clipboardEvent = new ClipboardEvent("paste", {
+      clipboardData,
+    });
+    editor.dispatchEvent(clipboardEvent);
+  }, text);
+}
+
+async function triggerPaste(page, text) {
+  await page.keyboard.type(`${text}\n`);
+  await page.locator("#editor").getByText(`${text}\n`).selectText();
   await page.keyboard.press("ControlOrMeta+X");
   await page.keyboard.press("ControlOrMeta+V");
+}
+
+async function paste(page, browserName, text) {
+  await page.locator('#editor [contenteditable="true"]').focus();
+
+  // We are unable to trigger the browser paste event in Chrome
+  // and the simulated paste event does not work in FireFox.
+  if (browserName === "firefox") {
+    await triggerPaste(page, text);
+  } else {
+    await simulatePaste(page, text);
+  }
+}
+
+test("parses pasted markdown", async ({ page, browserName }) => {
+  await expect(page.locator('#editor [src="/example.jpg"]')).toHaveCount(1);
+  await paste(page, browserName, "[Image: example.jpg]");
   await expect(page.locator('#editor [src="/example.jpg"]')).toHaveCount(2);
 });
 
-test("invalid markdown is pasted with placeholder", async ({ page }) => {
-  await page.locator('#editor [contenteditable="true"]').focus();
-  await page.keyboard.type("[Image: example-2.jpg]\n");
-  await page
-    .locator("#editor")
-    .getByText("[Image: example-2.jpg]")
-    .selectText();
-  await page.keyboard.press("ControlOrMeta+X");
-  await page.keyboard.press("ControlOrMeta+V");
+test("invalid markdown is pasted with placeholder", async ({
+  page,
+  browserName,
+}) => {
+  await paste(page, browserName, "[Image: example-2.jpg]");
   await expect(
     page.locator(".visual-editor__highlight--image-error"),
   ).toHaveCount(2);

--- a/e2e/images.spec.js
+++ b/e2e/images.spec.js
@@ -49,10 +49,8 @@ test("invalid markdown is pasted with placeholder", async ({ page }) => {
   await page.keyboard.press("ControlOrMeta+X");
   await page.keyboard.press("ControlOrMeta+V");
   await expect(
-    page.locator(".visual-editor__highlight--image-error [markdown]"),
-  ).toBeVisible();
-  await page
-    .locator(".visual-editor__highlight--image-error [markdown]")
-    .click();
+    page.locator(".visual-editor__highlight--image-error"),
+  ).toHaveCount(2);
+  await page.locator(".visual-editor__highlight--image-error").first().click();
   await expect(page.getByText("Image not found.")).toBeVisible();
 });


### PR DESCRIPTION
- Update image error locators
- Simulate paste events for chrome

Triggering the browser clipboard functionality using keyboard shortcuts doesn't work in headless chrome (i.e. when tests are run in github actions).
This means that the images tests for paste parsing were always failing.
By simulating the events instead of we avoid that issue.

This approach unfortunately does not work in firefox, so we keep the old approach there
