### PR TITLE
Configure Dependabot for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,15 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
-    dependency-type: production
+    # Security updates only: with no `allow` block, all dependencies (prod and
+    # dev) are eligible. Ignoring every routine semver bump suppresses version
+    # PRs without touching security updates (`update-types` never affects them).
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     schedule:
       interval: daily
     open-pull-requests-limit: 0


### PR DESCRIPTION
Replaces the `allow: production` filter with an `ignore` block that drops all routine semver version bumps (major, minor, patch) for every dependency. With no `allow` block, both production and development dependencies remain eligible for security updates, which `update-types` does not affect.

See the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).

This has been agreed with @ChrisBAshton for how we want our JS repos currently setup.