### PR TITLE
Bump CI Node version from 18 to 22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Run lint

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Run prettier

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Run Unit tests


### PR DESCRIPTION
## What

Bumps the Node version in all CI workflows from 18 to 22 (active LTS).

## Why

Dependency bumps to Vite 8 and Vitest 4 (see #395) require Node `^20.19.0 || >=22.12.0`. Our workflows pin Node 18, so those PRs fail CI with two distinct errors:

- **Vitest:** `SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'`
- **Playwright:** the dev server crashes on startup with `ReferenceError: CustomEvent is not defined`

Bumping CI to Node 22 unblocks them. Landing this separately on `main` first means the fix survives Dependabot rebasing #395 — once merged, #395 can be rebased and should go green.

Affected workflows: `vitest.yml`, `playwright.yml`, `lint.yml`, `prettier.yml`.